### PR TITLE
Downgrade Scalaz to 7.1.4.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val standardSettings = Seq(
 
   console <<= console in Test, // console alias test:console
 
-  scalazVersion := "7.1.7",
+  scalazVersion := "7.1.4",
   slcVersion    := "0.4",
 
   libraryDependencies ++= Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
quasar-analytics/quasar runs into issues with 7.1.7, so we downgrade
here to avoid forcing an upgrade there.