### PR TITLE
Changes by/for @tpolecat.

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,5 @@
+* Adds `Corecursive[Cofree[?[_], A]]` when `A` has a `Monoid`,
+* adds various operations decomposing `{co}elgot`,
+* modifies `attributeTopDown` to handle the projection,
+* generalizes `ElgotAlgebra`, and
+* eliminates `CoelgotAlgebra` (it’s identical to `CoalgebraM`).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All of these types have instances for `Recursive`, `Corecursive`, `FunctorT`, `T
 - `Fix` – This is the simplest fixpoint type, implemented with general recursion.
 - `Mu` – This is for inductive (finite) recursive structures, models the concept of “data”, aka, the “least fixed point”.
 - `Nu` – This is for coinductive (potentially infinite) recursive structures, models the concept of “codata”, aka, the “greatest fixed point’.
-- `Cofree[?[_], A]` – Does not have a `Corecursive` instance. This represents a structure with some metadata attached to each node. In addition to the usual operations, it can also be folded using an Elgot algebra.
+- `Cofree[?[_], A]` – Only has a `Corecursive` instance if there’s a `Monoid` for `A`. This represents a structure with some metadata attached to each node. In addition to the usual operations, it can also be folded using an Elgot algebra.
 - `Free[?[_], A]` – Does not have a `Recursive` instance. In addition to the usual operations, it can also be created by unfolding with an Elgot coalgebra.
 
 So a type like `Mu[Expr]` is now isomorphic to the original recursive type. However, the point is to avoid operating on recursive types directly …

--- a/core/src/main/scala/matryoshka/AlgebraOps.scala
+++ b/core/src/main/scala/matryoshka/AlgebraOps.scala
@@ -23,5 +23,6 @@ sealed class AlgebraOps[F[_], A](self: Algebra[F, A]) {
   def generalize[W[_]: Comonad](implicit F: Functor[F]): GAlgebra[W, F, A] =
     node => self(node ∘ (_.copoint))
 
-  def generalizeElgot[B]: ElgotAlgebra[F, B, A] = (a, node) => self(node)
+  def generalizeElgot[W[_]: Comonad]: ElgotAlgebra[W, F, A] =
+    w => self(w.copoint)
 }

--- a/core/src/main/scala/matryoshka/CofreeOps.scala
+++ b/core/src/main/scala/matryoshka/CofreeOps.scala
@@ -17,13 +17,18 @@
 package matryoshka
 
 import scalaz._
-import scalaz.syntax.monad._
 
-sealed class CoalgebraOps[F[_], A](self: Coalgebra[F, A]) {
-  def generalize[M[_]: Monad](implicit F: Functor[F]): GCoalgebra[M, F, A] =
-    self(_).map(_.map(_.point[M]))
+sealed class CofreeOps[F[_], A](self: Cofree[F, A]) {
+  def elgotCata[B](φ: ((A, F[B])) => B)(implicit F: Functor[F]): B =
+    matryoshka.elgotCata(self)(φ)
 
-  def generalizeM[M[_]: Monad]: CoalgebraM[M, F, A] = self(_).point[M]
+  def elgotCataM[M[_]: Monad, B](
+    φ: ((A, F[B])) => M[B])(
+    implicit F: Traverse[F]):
+      M[B] =
+    matryoshka.elgotCataM(self)(φ)
 
-  def generalizeElgot[M[_]: Monad]: CoalgebraM[M, F, A] = self.generalizeM
+  def cofCataM[M[_]: Monad, B](f: (A, F[B]) => M[B])(implicit F: Traverse[F]):
+      M[B] =
+    matryoshka.cofCataM(self)(f)
 }

--- a/core/src/main/scala/matryoshka/FreeOps.scala
+++ b/core/src/main/scala/matryoshka/FreeOps.scala
@@ -17,13 +17,8 @@
 package matryoshka
 
 import scalaz._
-import scalaz.syntax.monad._
 
-sealed class CoalgebraOps[F[_], A](self: Coalgebra[F, A]) {
-  def generalize[M[_]: Monad](implicit F: Functor[F]): GCoalgebra[M, F, A] =
-    self(_).map(_.map(_.point[M]))
-
-  def generalizeM[M[_]: Monad]: CoalgebraM[M, F, A] = self(_).point[M]
-
-  def generalizeElgot[M[_]: Monad]: CoalgebraM[M, F, A] = self.generalizeM
+sealed class FreeOps[F[_], A](self: Free[F, A]) {
+  def interpretCata(φ: F[A] => A)(implicit F: Functor[F]): A =
+    matryoshka.interpretCata(self)(φ)
 }

--- a/core/src/main/scala/matryoshka/IdOps.scala
+++ b/core/src/main/scala/matryoshka/IdOps.scala
@@ -37,14 +37,24 @@ sealed class IdOps[A](self: A) {
       B =
     matryoshka.chrono(self)(g, f)
 
+  def attributeAna[F[_]: Functor](ψ: A => F[A]): Cofree[F, A] =
+    matryoshka.attributeAna(self)(ψ)
+
+  def attributeAnaM[M[_]: Monad, F[_]: Traverse](ψ: A => M[F[A]]):
+      M[Cofree[F, A]] =
+    matryoshka.attributeAnaM(self)(ψ)
+
+  def elgotAna[F[_]: Functor, B](ψ: A => B \/ F[A]): Free[F, B] =
+    matryoshka.elgotAna(self)(ψ)
+
   def elgot[F[_]: Functor, B](φ: F[B] => B, ψ: A => B \/ F[A]): B =
     matryoshka.elgot(self)(φ, ψ)
 
-  def coelgot[F[_]: Functor, B](φ: (A, F[B]) => B, ψ: A => F[A]): B =
+  def coelgot[F[_]: Functor, B](φ: ((A, F[B])) => B, ψ: A => F[A]): B =
     matryoshka.coelgot(self)(φ, ψ)
   def coelgotM[M[_]] = new CoelgotMPartiallyApplied[M]
   final class CoelgotMPartiallyApplied[M[_]] {
-    def apply[F[_]: Traverse, B](φ: (A, F[B]) => M[B], ψ: A => M[F[A]])(implicit M: Monad[M]):
+    def apply[F[_]: Traverse, B](φ: ((A, F[B])) => M[B], ψ: A => M[F[A]])(implicit M: Monad[M]):
         M[B] =
       matryoshka.coelgotM[M].apply[F, A, B](self)(φ, ψ)
   }

--- a/core/src/main/scala/matryoshka/cofree.scala
+++ b/core/src/main/scala/matryoshka/cofree.scala
@@ -26,6 +26,11 @@ trait CofreeInstances {
       def project[F[_]: Functor](t: Cofree[F, A]) = t.tail
     }
 
+  implicit def cofreeCorecursive[A: Monoid]: Corecursive[Cofree[?[_], A]] =
+    new Corecursive[Cofree[?[_], A]] {
+      def embed[F[_]: Functor](t: F[Cofree[F, A]]) = Cofree(Monoid[A].zero, t)
+    }
+
   implicit def cofreeTraverseT[A]: TraverseT[Cofree[?[_], A]] =
     new TraverseT[Cofree[?[_], A]] {
       def traverse[M[_]: Applicative, F[_]: Functor, G[_]: Functor](t: Cofree[F, A])(f: F[Cofree[F, A]] => M[G[Cofree[G, A]]]) =

--- a/core/src/main/scala/matryoshka/free.scala
+++ b/core/src/main/scala/matryoshka/free.scala
@@ -19,17 +19,17 @@ package matryoshka
 import scalaz._, Scalaz._
 
 trait FreeInstances {
-  implicit def FreeTraverseT[A]: TraverseT[Free[?[_], A]] =
+  implicit def freeCorecursive[A]: Corecursive[Free[?[_], A]] =
+    new Corecursive[Free[?[_], A]] {
+      def embed[F[_]: Functor](t: F[Free[F, A]]) = Free.liftF(t).join
+    }
+
+  implicit def freeTraverseT[A]: TraverseT[Free[?[_], A]] =
     new TraverseT[Free[?[_], A]] {
       def traverse[M[_]: Applicative, F[_]: Functor, G[_]: Functor](t: Free[F, A])(f: F[Free[F, A]] => M[G[Free[G, A]]]) =
         t.fold(
           _.point[Free[G, ?]].point[M],
           f(_).map(Free.liftF(_).join))
-    }
-
-  implicit def FreeCorecursive[A]: Corecursive[Free[?[_], A]] =
-    new Corecursive[Free[?[_], A]] {
-      def embed[F[_]: Functor](t: F[Free[F, A]]) = Free.liftF(t).join
     }
 }
 

--- a/core/src/test/scala/matryoshka/spec.scala
+++ b/core/src/test/scala/matryoshka/spec.scala
@@ -308,15 +308,29 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
       }
     }
 
+    "coelgot" should {
+      "behave like elgotCata ⋘ attributeAna" ! prop { (i: Int) =>
+        i.coelgot(eval.generalizeElgot[(Int, ?)], extractFactors) must equal(
+          i.attributeAna(extractFactors).elgotCata(eval.generalizeElgot[(Int, ?)]))
+      }
+    }
+
+    "elgot" should {
+      "behave like interpCata ⋘ elgotAna" ! prop { (i: Int) =>
+        i.elgot(eval, extractFactors.generalizeElgot[Int \/ ?]) must equal(
+          i.elgotAna(extractFactors.generalizeElgot[Int \/ ?]).interpretCata(eval))
+      }
+    }
+
     "generalizeElgot" should {
       "behave like cata on an algebra" ! prop { (i: Int) =>
         val x = i.ana(extractFactors).cata(eval)
-        i.coelgot(eval.generalizeElgot[Int], extractFactors) must equal(x)
+        i.coelgot(eval.generalizeElgot[(Int, ?)], extractFactors) must equal(x)
       }
 
       "behave like ana on an coalgebra" ! prop { (i: Int) =>
         val x = i.ana(extractFactors).cata(eval)
-        i.elgot(eval, extractFactors.generalizeElgot[Int]) must equal(x)
+        i.elgot(eval, extractFactors.generalizeElgot[Int \/ ?]) must equal(x)
       }
     }
 
@@ -402,9 +416,9 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
       }
     }
 
-    def depth[T[_[_]], F[_]]: (Int, T[F]) => Int = (i, _) => i + 1
+    def depth[T[_[_]], F[_]]: (Int, F[T[F]]) => Int = (i, _) => i + 1
 
-    def sequential[T[_[_]], F[_]]: (Int, T[F]) => State[Int, Int] =
+    def sequential[T[_[_]], F[_]]: (Int, F[T[F]]) => State[Int, Int] =
       (_, _) => State.get[Int] <* State.modify[Int](_ + 1)
 
     "attributeTopDown" should {


### PR DESCRIPTION
* Adds `Corecursive[Cofree[?[_], A]]` when `A` has a `Monoid`,
* adds various operations decomposing `{co}elgot`,
* modifies `attributeTopDown` to handle the projection,
* generalizes `ElgotAlgebra`, and
* eliminates `CoelgotAlgebra` (it’s identical to `CoalgebraM`).