### PR TITLE
Add “elgot” versions of various {un}folds.

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,4 @@
+- add `elgot*` versions of various {un}folds
+- be more consistent about type parameter order
+- rename the old `elgotCata` to `cofCata` (and delete `elgotCataM`, which was a duplicate of `cofCataM`)
+- rename the old `elgotAna` to `freeAna`

--- a/core/src/main/scala/matryoshka/CofreeOps.scala
+++ b/core/src/main/scala/matryoshka/CofreeOps.scala
@@ -19,16 +19,12 @@ package matryoshka
 import scalaz._
 
 sealed class CofreeOps[F[_], A](self: Cofree[F, A]) {
-  def elgotCata[B](φ: ((A, F[B])) => B)(implicit F: Functor[F]): B =
-    matryoshka.elgotCata(self)(φ)
+  def cofCata[B](φ: ((A, F[B])) => B)(implicit F: Functor[F]): B =
+    matryoshka.cofCata(self)(φ)
 
-  def elgotCataM[M[_]: Monad, B](
+  def cofCataM[M[_]: Monad, B](
     φ: ((A, F[B])) => M[B])(
     implicit F: Traverse[F]):
       M[B] =
-    matryoshka.elgotCataM(self)(φ)
-
-  def cofCataM[M[_]: Monad, B](f: (A, F[B]) => M[B])(implicit F: Traverse[F]):
-      M[B] =
-    matryoshka.cofCataM(self)(f)
+    matryoshka.cofCataM(self)(φ)
 }

--- a/core/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/src/main/scala/matryoshka/Corecursive.scala
@@ -28,8 +28,7 @@ import simulacrum.typeclass
   def embed[F[_]: Functor](t: F[T[F]]): T[F]
 
   def ana[F[_]: Functor, A](a: A)(f: A => F[A]): T[F] =
-    // embed(f(a) ∘ (ana(_)(f)))
-    elgotAna[Id, F, A](a)(distAna, f)
+    embed(f(a) ∘ (ana(_)(f)))
 
   def anaM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[A]]): M[T[F]] =
     f(a).flatMap(_.traverse(anaM(_)(f))) ∘ (embed(_))

--- a/core/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/src/main/scala/matryoshka/Corecursive.scala
@@ -28,46 +28,66 @@ import simulacrum.typeclass
   def embed[F[_]: Functor](t: F[T[F]]): T[F]
 
   def ana[F[_]: Functor, A](a: A)(f: A => F[A]): T[F] =
-    embed(f(a) ∘ (ana(_)(f)))
+    // embed(f(a) ∘ (ana(_)(f)))
+    elgotAna[Id, F, A](a)(distAna, f)
 
   def anaM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[A]]): M[T[F]] =
     f(a).flatMap(_.traverse(anaM(_)(f))) ∘ (embed(_))
 
-  def gana[F[_]: Functor, M[_], A](
+  def gana[M[_], F[_]: Functor, A](
     a: A)(
     k: DistributiveLaw[M, F], f: A => F[M[A]])(
     implicit M: Monad[M]):
       T[F] = {
-    def loop(x: M[F[M[A]]]): T[F] =
-      embed(k(x) ∘ (x => loop(M.lift(f)(x.join))))
+    def loop(x: M[F[M[A]]]): T[F] = embed(k(x) ∘ (x => loop(M.lift(f)(x.join))))
 
     loop(f(a).point[M])
+  }
+
+  def elgotAna[M[_], F[_]: Functor, A](
+    a: A)(
+    k: DistributiveLaw[M, F], ψ: A => M[F[A]])(
+    implicit M: Monad[M]):
+      T[F] = {
+    def loop(x: M[F[A]]): T[F] = embed(k(x) ∘ (x => loop(M.lift(ψ)(x).join)))
+
+    loop(ψ(a))
   }
 
   def apo[F[_]: Functor, A](a: A)(f: A => F[T[F] \/ A]): T[F] =
     embed(f(a) ∘ (_.fold(Predef.identity, apo(_)(f))))
 
+  def elgotApo[F[_]: Functor, A](a: A)(f: A => T[F] \/ F[A]): T[F] =
+    f(a).fold(Predef.identity, fa => embed(fa ∘ (elgotApo(_)(f))))
+
   def apoM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[T[F] \/ A]]): M[T[F]] =
     f(a).flatMap(_.traverse(_.fold(_.point[M], apoM(_)(f)))) ∘ (embed(_))
 
-  def postpro[F[_]: Functor, A](a: A)(e: F ~> F, g: A => F[A])(implicit T: Recursive[T]): T[F] =
-    embed(g(a) ∘ (x => ana(postpro(x)(e, g))(x => e(x.project))))
-
-  def gpostpro[F[_]: Functor, M[_], A](
+  def postpro[F[_]: Functor, A](
     a: A)(
-    k: DistributiveLaw[M, F], e: F ~> F, g: A => F[M[A]])(
+    e: F ~> F, g: A => F[A])(
+    implicit T: Recursive[T]):
+      T[F] =
+    gpostpro[Id, F, A](a)(distAna, e, g)
+
+  def gpostpro[M[_], F[_]: Functor, A](
+    a: A)(
+    k: DistributiveLaw[M, F], e: F ~> F, ψ: A => F[M[A]])(
     implicit T: Recursive[T], M: Monad[M]):
       T[F] = {
     def loop(ma: M[A]): T[F] =
-      embed(k(M.lift(g)(ma)) ∘ (x => ana(loop(x.join))(x => e(x.project))))
+      embed(k(M.lift(ψ)(ma)) ∘ (x => ana(loop(x.join))(x => e(x.project))))
 
     loop(a.point[M])
   }
 
   def futu[F[_]: Functor, A](a: A)(f: A => F[Free[F, A]]): T[F] =
-    gana[F, Free[F, ?], A](a)(distFutu, f)
+    gana[Free[F, ?], F, A](a)(distFutu, f)
 
-  def futuM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[Free[F, A]]]):
+  def elgotFutu[F[_]: Functor, A](a: A)(f: A => Free[F, F[A]]): T[F] =
+    elgotAna[Free[F, ?], F, A](a)(distFutu, f)
+
+  def futuM[M[_]: Monad, F[_]: Traverse, A](a: A)(f: A => M[F[Free[F, A]]]):
       M[T[F]] = {
     def loop(free: Free[F, A]): M[T[F]] =
       free.fold(futuM(_)(f), _.traverse(loop) ∘ (embed[F]))

--- a/core/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/src/main/scala/matryoshka/Corecursive.scala
@@ -54,9 +54,13 @@ import simulacrum.typeclass
   }
 
   def apo[F[_]: Functor, A](a: A)(f: A => F[T[F] \/ A]): T[F] =
+    // NB: This is not implemented with [[matryoshka.distApo]] because that
+    //     would add a [[matryoshka.Recursive]] constraint.
     embed(f(a) ∘ (_.fold(Predef.identity, apo(_)(f))))
 
   def elgotApo[F[_]: Functor, A](a: A)(f: A => T[F] \/ F[A]): T[F] =
+    // NB: This is not implemented with [[matryoshka.distApo]] because that
+    //     would add a [[matryoshka.Recursive]] constraint.
     f(a).fold(Predef.identity, fa => embed(fa ∘ (elgotApo(_)(f))))
 
   def apoM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[T[F] \/ A]]): M[T[F]] =

--- a/core/src/main/scala/matryoshka/IdOps.scala
+++ b/core/src/main/scala/matryoshka/IdOps.scala
@@ -61,27 +61,34 @@ sealed class IdOps[A](self: A) {
 
   def ana[T[_[_]], F[_]: Functor](f: A => F[A])(implicit T: Corecursive[T]): T[F] =
     T.ana(self)(f)
-  def anaM[T[_[_]], F[_]: Traverse, M[_]: Monad](f: A => M[F[A]])(implicit T: Corecursive[T]): M[T[F]] =
+  def anaM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[A]])(implicit T: Corecursive[T]): M[T[F]] =
     T.anaM(self)(f)
-  def gana[T[_[_]], F[_]: Functor, M[_]: Monad](
+  def gana[T[_[_]], M[_]: Monad, F[_]: Functor](
     k: DistributiveLaw[M, F], f: A => F[M[A]])(
     implicit T: Corecursive[T]):
       T[F] =
     T.gana(self)(k, f)
+  def elgotAna[T[_[_]], M[_]: Monad, F[_]: Functor](
+    k: DistributiveLaw[M, F], f: A => M[F[A]])(
+    implicit T: Corecursive[T]):
+      T[F] =
+    T.elgotAna(self)(k, f)
   def apo[T[_[_]], F[_]: Functor](f: A => F[T[F] \/ A])(implicit T: Corecursive[T]): T[F] =
     T.apo(self)(f)
-  def apoM[T[_[_]], F[_]: Traverse, M[_]: Monad](f: A => M[F[T[F] \/ A]])(implicit T: Corecursive[T]): M[T[F]] =
+  def elgotApo[T[_[_]], F[_]: Functor](f: A => T[F] \/ F[A])(implicit T: Corecursive[T]): T[F] =
+    T.elgotApo(self)(f)
+  def apoM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[T[F] \/ A]])(implicit T: Corecursive[T]): M[T[F]] =
     T.apoM(self)(f)
   def postpro[T[_[_]]: Recursive, F[_]: Functor](e: F ~> F, g: A => F[A])(implicit T: Corecursive[T]): T[F] =
     T.postpro(self)(e, g)
-  def gpostpro[T[_[_]]: Recursive, F[_]: Functor, M[_]: Monad](
+  def gpostpro[T[_[_]]: Recursive, M[_]: Monad, F[_]: Functor](
     k: DistributiveLaw[M, F], e: F ~> F, g: A => F[M[A]])(
     implicit T: Corecursive[T]):
       T[F] =
     T.gpostpro(self)(k, e, g)
   def futu[T[_[_]], F[_]: Functor](f: A => F[Free[F, A]])(implicit T: Corecursive[T]): T[F] =
     T.futu(self)(f)
-  def futuM[T[_[_]], F[_]: Traverse, M[_]: Monad](f: A => M[F[Free[F, A]]])(implicit T: Corecursive[T]):
+  def futuM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[Free[F, A]]])(implicit T: Corecursive[T]):
       M[T[F]] =
     T.futuM(self)(f)
 }

--- a/core/src/main/scala/matryoshka/IdOps.scala
+++ b/core/src/main/scala/matryoshka/IdOps.scala
@@ -44,8 +44,8 @@ sealed class IdOps[A](self: A) {
       M[Cofree[F, A]] =
     matryoshka.attributeAnaM(self)(ψ)
 
-  def elgotAna[F[_]: Functor, B](ψ: A => B \/ F[A]): Free[F, B] =
-    matryoshka.elgotAna(self)(ψ)
+  def freeAna[F[_]: Functor, B](ψ: A => B \/ F[A]): Free[F, B] =
+    matryoshka.freeAna(self)(ψ)
 
   def elgot[F[_]: Functor, B](φ: F[B] => B, ψ: A => B \/ F[A]): B =
     matryoshka.elgot(self)(φ, ψ)

--- a/core/src/main/scala/matryoshka/Recursive.scala
+++ b/core/src/main/scala/matryoshka/Recursive.scala
@@ -27,8 +27,7 @@ import simulacrum.typeclass
   def project[F[_]: Functor](t: T[F]): F[T[F]]
 
   def cata[F[_]: Functor, A](t: T[F])(f: F[A] => A): A =
-    // f(project(t) ∘ (cata(_)(f)))
-    elgotCata[Id, F, A](t)(distCata, f)
+    f(project(t) ∘ (cata(_)(f)))
 
   /** A Kleisli catamorphism. */
   def cataM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: F[A] => M[A]): M[A] =

--- a/core/src/main/scala/matryoshka/Recursive.scala
+++ b/core/src/main/scala/matryoshka/Recursive.scala
@@ -27,12 +27,15 @@ import simulacrum.typeclass
   def project[F[_]: Functor](t: T[F]): F[T[F]]
 
   def cata[F[_]: Functor, A](t: T[F])(f: F[A] => A): A =
-    f(project(t) ∘ (cata(_)(f)))
+    // f(project(t) ∘ (cata(_)(f)))
+    elgotCata[Id, F, A](t)(distCata, f)
 
+  /** A Kleisli catamorphism. */
   def cataM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: F[A] => M[A]): M[A] =
     project(t).traverse(cataM(_)(f)).flatMap(f)
 
-  def gcata[F[_]: Functor, W[_]: Comonad, A](
+  /** A catamorphism generalized with a comonad in inside the functor. */
+  def gcata[W[_]: Comonad, F[_]: Functor, A](
     t: T[F])(
     k: DistributiveLaw[F, W], g: F[W[A]] => A):
       A = {
@@ -41,8 +44,25 @@ import simulacrum.typeclass
     g(loop(t).copoint)
   }
 
+  /** A catamorphism generalized with a comonad outside the functor. */
+  def elgotCata[W[_]: Comonad, F[_]: Functor, A](
+    t: T[F])(
+    k: DistributiveLaw[F, W], g: ElgotAlgebra[W, F, A]):
+      A = {
+    def loop(t: T[F]): W[F[A]] = k(project(t) ∘ (loop(_).cojoin.map(g)))
+
+    g(loop(t))
+  }
+
   def para[F[_]: Functor, A](t: T[F])(f: F[(T[F], A)] => A): A =
+    // NB: This is not implemented with [[matryoshka.distPara]] because that
+    //     would add a [[matryoshka.Corecursive]] constraint.
     f(project(t) ∘ (t => (t, para(t)(f))))
+
+  def elgotPara[F[_]: Functor, A](t: T[F])(f: ((T[F], F[A])) => A): A =
+    // NB: This is not implemented with [[matryoshka.distPara]] because that
+    //     would add a [[matryoshka.Corecursive]] constraint.
+    f((t, project(t) ∘ (elgotPara(_)(f))))
 
   def paraM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: F[(T[F], A)] => M[A]):
       M[A] =
@@ -56,13 +76,17 @@ import simulacrum.typeclass
     gzygo[F, W, A, T[F]](t)(T.embed(_), e, f)
 
   def zygo[F[_]: Functor, A, B](t: T[F])(f: F[B] => B, g: F[(B, A)] => A): A =
-    gcata[F, (B, ?), A](t)(distZygo(f), g)
+    gcata[(B, ?), F, A](t)(distZygo(f), g)
+
+  def elgotZygo[F[_]: Functor, A, B](t: T[F])(f: F[B] => B, g: ElgotAlgebra[(B, ?), F, A]):
+      A =
+    elgotCata[(B, ?), F, A](t)(distZygo(f), g)
 
   def gzygo[F[_]: Functor, W[_]: Comonad, A, B](
     t: T[F])(
     f: F[B] => B, w: DistributiveLaw[F, W], g: F[EnvT[B, W, A]] => A):
       A =
-    gcata[F, EnvT[B, W, ?], A](t)(distZygoT(f, w), g)
+    gcata[EnvT[B, W, ?], F, A](t)(distZygoT(f, w), g)
 
   /** Mutually-recursive fold. */
   def mutu[F[_]: Functor, A, B](t: T[F])(f: F[(A, B)] => B, g: F[(B, A)] => A):
@@ -70,13 +94,16 @@ import simulacrum.typeclass
     g(project(t) ∘ (x => (mutu(x)(g, f), mutu(x)(f, g))))
 
   def histo[F[_]: Functor, A](t: T[F])(f: F[Cofree[F, A]] => A): A =
-    gcata[F, Cofree[F, ?], A](t)(distHisto, f)
+    gcata[Cofree[F, ?], F, A](t)(distHisto, f)
+
+  def elgotHisto[F[_]: Functor, A](t: T[F])(f: Cofree[F, F[A]] => A): A =
+    elgotCata[Cofree[F, ?], F, A](t)(distHisto, f)
 
   def ghisto[F[_]: Functor, H[_]: Functor, A](
     t: T[F])(
     g: DistributiveLaw[F, H], f: F[Cofree[H, A]] => A):
       A =
-    gcata[F, Cofree[H, ?], A](t)(distGHisto(g), f)
+    gcata[Cofree[H, ?], F, A](t)(distGHisto(g), f)
 
   def paraZygo[F[_]:Functor: Unzip, A, B](
     t: T[F]) (

--- a/core/src/main/scala/matryoshka/package.scala
+++ b/core/src/main/scala/matryoshka/package.scala
@@ -97,8 +97,7 @@ package object matryoshka extends CofreeInstances with FreeInstances {
     * intermediate recursive data structure.
     */
   def hylo[F[_]: Functor, A, B](a: A)(f: F[B] => B, g: A => F[A]): B =
-    // f(g(a) ∘ (hylo(_)(f, g)))
-    ghylo[Id, Id, F, A, B](a)(distCata, distAna, f, g)
+    f(g(a) ∘ (hylo(_)(f, g)))
 
   /** A Kleisli hylomorphism. */
   def hyloM[M[_]: Monad, F[_]: Traverse, A, B](a: A)(f: F[B] => M[B], g: A => M[F[A]]):

--- a/core/src/main/scala/matryoshka/package.scala
+++ b/core/src/main/scala/matryoshka/package.scala
@@ -150,7 +150,7 @@ package object matryoshka extends CofreeInstances with FreeInstances {
     }
   }
 
-  def distPara[T[_[_]], F[_]: Functor](implicit T: Corecursive[T]):
+  def distPara[T[_[_]]: Corecursive, F[_]: Functor]:
       DistributiveLaw[F, (T[F], ?)] =
     distZygo(_.embed)
 
@@ -194,6 +194,15 @@ package object matryoshka extends CofreeInstances with FreeInstances {
     }
 
   def distAna[F[_]]: DistributiveLaw[Id, F] = NaturalTransformation.refl
+
+  def distApo[T[_[_]]: Recursive, F[_]: Functor]:
+      DistributiveLaw[T[F] \/ ?, F] =
+    distGApo(_.project)
+
+  def distGApo[F[_]: Functor, B](g: B => F[B]) =
+    new DistributiveLaw[B \/ ?, F] {
+      def apply[α](m: B \/ F[α]) = m.fold(g(_) ∘ (_.left), _ ∘ (_.right))
+    }
 
   def distFutu[F[_]: Functor] =
     new DistributiveLaw[Free[F, ?], F] {

--- a/core/src/test/scala/matryoshka/spec.scala
+++ b/core/src/test/scala/matryoshka/spec.scala
@@ -766,6 +766,30 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
         Mul(Free.liftF(Num(3)), Free.liftF(Num(x/3)))
       else Num(x)
 
+    "postpro" should {
+      "extract original with identity ~>" in {
+        72.postpro(NaturalTransformation.refl[Exp], extractFactors) must
+          equal(mul(num(2), mul(num(2), mul(num(2), num(9)))))
+      }
+
+      "apply ~> repeatedly" in {
+        72.postpro(MinusThree, extractFactors) must
+          equal(mul(num(-1), mul(num(-4), mul(num(-7), num(0)))))
+      }
+    }
+
+    "gpostpro" should {
+      "extract original with identity ~>" in {
+        72.gpostpro[Fix, Exp, Free[Exp, ?]](distFutu, NaturalTransformation.refl[Exp], extract2and3) must
+          equal(mul(num(2), mul(num(2), mul(num(2), mul(num(3), num(3))))))
+      }
+
+      "apply ~> repeatedly" in {
+        72.gpostpro[Fix, Exp, Free[Exp, ?]](distFutu, MinusThree, extract2and3) must
+          equal(mul(num(-1), mul(num(-4), mul(num(-7), mul(num(-9), num(-9))))))
+      }
+    }
+
     "futu" should {
       "factor multiples of two" in {
         8.futu(extract2and3) must equal(mul(num(2), mul(num(2), num(2))))

--- a/core/src/test/scala/matryoshka/spec.scala
+++ b/core/src/test/scala/matryoshka/spec.scala
@@ -441,16 +441,16 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
     }
 
     "coelgot" should {
-      "behave like elgotCata ⋘ attributeAna" ! prop { (i: Int) =>
+      "behave like cofCata ⋘ attributeAna" ! prop { (i: Int) =>
         i.coelgot(eval.generalizeElgot[(Int, ?)], extractFactors) must equal(
-          i.attributeAna(extractFactors).elgotCata(eval.generalizeElgot[(Int, ?)]))
+          i.attributeAna(extractFactors).cofCata(eval.generalizeElgot[(Int, ?)]))
       }
     }
 
     "elgot" should {
-      "behave like interpCata ⋘ elgotAna" ! prop { (i: Int) =>
+      "behave like interpCata ⋘ freeAna" ! prop { (i: Int) =>
         i.elgot(eval, extractFactors.generalizeElgot[Int \/ ?]) must equal(
-          i.elgotAna(extractFactors.generalizeElgot[Int \/ ?]).interpretCata(eval))
+          i.freeAna(extractFactors.generalizeElgot[Int \/ ?]).interpretCata(eval))
       }
     }
 


### PR DESCRIPTION
The Elgot generalization of an algebra puts the {co}monad in a different place. E.g.
```scala
F[A] => A
```
normally generalizes to
```scala
F[W[A]] => A
```
but the Elgot generalization is
```scala
W[F[A]] => A
```