### PR TITLE
Move Arbitrary instances and tests into their own subprojects.

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,2 @@
+- expose `matryoshka-scalacheck` as a separate jar with Arbitrary instances
+- move tests into a separate subproject (so they can depend on matryoshka-scalacheck) and start breaking them into more reasonable pieces

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,13 @@
-import CustomKeys._
-
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.license.Apache2_0
 import scoverage._
 import sbt._, Keys._
 
 lazy val checkHeaders = taskKey[Unit]("Fail the build if createHeaders is not up-to-date")
+
+val scalacheckVersion = "1.11.6"
+val scalazVersion     = "7.1.7"
+val slcVersion        = "0.4"
 
 lazy val standardSettings = Seq(
   headers := Map(
@@ -56,18 +58,15 @@ lazy val standardSettings = Seq(
 
   console <<= console in Test, // console alias test:console
 
-  scalazVersion := "7.1.7",
-  slcVersion    := "0.4",
-
   libraryDependencies ++= Seq(
-    "org.scalaz"        %% "scalaz-core"               % scalazVersion.value % "compile, test",
-    "org.typelevel"     %% "shapeless-scalaz"          % slcVersion.value    % "compile, test",
-    "com.github.mpilquist" %% "simulacrum"             % "0.7.0"             % "compile, test",
-    "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion.value % "test",
-    "org.specs2"        %% "specs2-core"               % "2.4"               % "test",
-    "org.scalacheck"    %% "scalacheck"                % "1.11.6"            % "test" force(),
-    "org.typelevel"     %% "scalaz-specs2"             % "0.3.0"             % "test",
-    "org.typelevel"     %% "shapeless-scalacheck"      % slcVersion.value    % "test"),
+    "org.scalaz"        %% "scalaz-core"               % scalazVersion     % "compile, test",
+    "org.typelevel"     %% "shapeless-scalaz"          % slcVersion        % "compile, test",
+    "com.github.mpilquist" %% "simulacrum"             % "0.7.0"           % "compile, test",
+    "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion     % "test",
+    "org.specs2"        %% "specs2-core"               % "2.4"             % "test",
+    "org.scalacheck"    %% "scalacheck"                % scalacheckVersion % "test" force(),
+    "org.typelevel"     %% "scalaz-specs2"             % "0.3.0"           % "test",
+    "org.typelevel"     %% "shapeless-scalacheck"      % slcVersion        % "test"),
 
   licenses += ("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0")),
 
@@ -134,17 +133,36 @@ lazy val publishSettings = Seq(
       email = "contact@slamdata.com",
       url = new URL("http://slamdata.com"))))
 
+lazy val noPublishSettings = Seq(
+  publish := (),
+  publishLocal := (),
+  publishArtifact := false)
+
 lazy val root = Project("root", file("."))
   .settings(standardSettings ++ publishSettings: _*)
-  .settings(Seq(
-    publish := (),
-    publishLocal := (),
-    publishArtifact := false))
+  .settings(noPublishSettings)
   .settings(name := "matryoshka")
-  .aggregate(core)
+  .aggregate(core, scalacheck, tests)
   .enablePlugins(AutomateHeaderPlugin)
 
-lazy val core = (project in file("core"))
+lazy val core = project
   .settings(standardSettings ++ publishSettings: _*)
   .settings(name := "matryoshka-core")
   .enablePlugins(AutomateHeaderPlugin)
+
+lazy val scalacheck = project
+  .dependsOn(core)
+  .settings(standardSettings ++ publishSettings: _*)
+  .settings(
+    name := "matryoshka-scalacheck",
+    libraryDependencies ++= Seq(
+      "org.scalacheck" %% "scalacheck"                % scalacheckVersion,
+      "org.scalaz"     %% "scalaz-scalacheck-binding" % scalazVersion))
+  .enablePlugins(AutomateHeaderPlugin)
+
+lazy val tests = project
+  .dependsOn(core, scalacheck)
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(standardSettings ++ publishSettings)
+  .settings(noPublishSettings)
+  .settings(name := "matryoshka-tests")

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,9 +3,3 @@ fork in run := true
 connectInput in run := true
 
 outputStrategy := Some(StdoutOutput)
-
-import scoverage._
-
-ScoverageKeys.coverageMinimum := 57
-
-ScoverageKeys.coverageFailOnMinimum := true

--- a/scalacheck/src/main/scala/matryoshka/scalacheck/arbitrary.scala
+++ b/scalacheck/src/main/scala/matryoshka/scalacheck/arbitrary.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.scalacheck
+
+import matryoshka._
+
+import org.scalacheck._
+import scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.syntax.monad._
+
+trait ArbitraryInstances0 {
+  implicit def corecursiveArbitrary[T[_[_]]: Corecursive, F[_]: Functor](
+    fArb: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary[T[F]] =
+    Arbitrary(Gen.sized(size =>
+      fArb(Arbitrary(
+        if (size <= 0)
+          Gen.fail[T[F]]
+        else
+          Gen.resize(size - 1, corecursiveArbitrary(fArb).arbitrary))).arbitrary ∘ (_.embed)))
+}
+
+trait ArbitraryInstances extends ArbitraryInstances0 {
+  // TODO: Submit these to Scalaz
+  implicit def cofreeArbitrary[F[_], A](
+    fArb: Arbitrary ~> λ[α => Arbitrary[F[α]]])(
+    implicit A: Arbitrary[A]):
+      Arbitrary[Cofree[F, A]] =
+    Arbitrary(
+      Gen.sized(size =>
+        (Gen.resize(size / 2, A.arbitrary) ⊛
+          fArb(Arbitrary(
+              if (size <= 0)
+                Gen.fail[Cofree[F, A]]
+              else
+                Gen.resize(size / 2, cofreeArbitrary(fArb).arbitrary))).arbitrary)(
+          Cofree(_, _))))
+
+  implicit def freeArbitrary[F[_]: Functor, A](
+    fArb: Arbitrary ~> λ[α => Arbitrary[F[α]]])(
+    implicit A: Arbitrary[A]):
+      Arbitrary[Free[F, A]] =
+    Arbitrary(
+      Gen.sized(size =>
+        Gen.resize(size - 1,
+          Gen.oneOf(
+            A.arbitrary ∘ (_.point[Free[F, ?]]),
+            fArb(Arbitrary(
+              if (size <= 0)
+                Gen.fail[Free[F, A]]
+              else
+                freeArbitrary(fArb).arbitrary)).arbitrary ∘ (Free.liftF(_).join)))))
+}
+
+package object arbitrary extends ArbitraryInstances

--- a/tests/src/test/scala/matryoshka/exp/Exp.scala
+++ b/tests/src/test/scala/matryoshka/exp/Exp.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.exp
+
+import java.lang.String
+import scala.{Boolean, Function, Int, None, Option, Predef, Symbol, Unit}
+
+import org.scalacheck._
+import org.specs2.scalaz._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.scalacheck.ScalazProperties._
+
+sealed trait Exp[A]
+case class Num[A](value: Int)                        extends Exp[A]
+case class Mul[A](left: A, right: A)                 extends Exp[A]
+case class Var[A](value: Symbol)                     extends Exp[A]
+case class Lambda[A](param: Symbol, body: A)         extends Exp[A]
+case class Apply[A](func: A, arg: A)                 extends Exp[A]
+case class Let[A](name: Symbol, value: A, inBody: A) extends Exp[A]
+
+object Exp {
+  implicit val arbSymbol = Arbitrary(Arbitrary.arbitrary[String].map(Symbol(_)))
+
+  implicit val arbitrary: Arbitrary ~> λ[α => Arbitrary[Exp[α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Exp[α]]]) {
+      def apply[α](arb: Arbitrary[α]): Arbitrary[Exp[α]] =
+        Arbitrary(Gen.oneOf(
+          Arbitrary.arbitrary[Int].map(Num[α](_)),
+          (arb.arbitrary ⊛ arb.arbitrary)(Mul(_, _)),
+          Arbitrary.arbitrary[Symbol].map(Var[α](_)),
+          (Arbitrary.arbitrary[Symbol] ⊛ arb.arbitrary)(Lambda(_, _)),
+          (arb.arbitrary ⊛ arb.arbitrary)(Apply(_, _)),
+          (Arbitrary.arbitrary[Symbol] ⊛ arb.arbitrary ⊛ arb.arbitrary)(
+            Let(_, _, _))))
+    }
+
+  implicit val traverse: Traverse[Exp] = new Traverse[Exp] {
+    def traverseImpl[G[_], A, B](fa: Exp[A])(f: A => G[B])(implicit G: Applicative[G]): G[Exp[B]] = fa match {
+      case Num(v)           => G.point(Num(v))
+      case Mul(left, right) => G.apply2(f(left), f(right))(Mul(_, _))
+      case Var(v)           => G.point(Var(v))
+      case Lambda(p, b)     => G.map(f(b))(Lambda(p, _))
+      case Apply(func, arg) => G.apply2(f(func), f(arg))(Apply(_, _))
+      case Let(n, v, i)     => G.apply2(f(v), f(i))(Let(n, _, _))
+    }
+  }
+
+  // NB: an unusual definition of equality, in that only the first 3 characters
+  //     of variable names are significant. This is to distinguish it from `==`
+  //     as well as from a derivable Equal.
+  implicit val equal: Equal ~> λ[α => Equal[Exp[α]]] =
+    new (Equal ~> λ[α => Equal[Exp[α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal[Exp[α]] {
+          case (Num(v1), Num(v2))                 => v1 ≟ v2
+          case (Mul(a1, b1), Mul(a2, b2))         =>
+            eq.equal(a1, a2) && eq.equal(b1, b2)
+          case (Var(s1), Var(s2))                 =>
+            s1.name.substring(0, 3 min s1.name.length) ==
+              s2.name.substring(0, 3 min s2.name.length)
+          case (Lambda(p1, a1), Lambda(p2, a2))   =>
+            p1 == p2 && eq.equal(a1, a2)
+          case (Apply(f1, a1), Apply(f2, a2))     =>
+            eq.equal(f1, f2) && eq.equal(a1, a2)
+          case (Let(n1, v1, i1), Let(n2, v2, i2)) =>
+            n1 == n2 && eq.equal(v1, v2) && eq.equal(i1, i2)
+          case _                                  => false
+        }
+    }
+  implicit def equal2[A](implicit A: Equal[A]): Equal[Exp[A]] = equal(A)
+
+  implicit val show: Show ~> λ[α => Show[Exp[α]]] =
+    new (Show ~> λ[α => Show[Exp[α]]]) {
+      def apply[α](show: Show[α]) =
+        Show.show {
+          case Num(v)       => v.shows
+          case Mul(a, b)    =>
+            "Mul(" + show.shows(a) + ", " + show.shows(b) + ")"
+          case Var(s)       => "$" + s.name
+          case Lambda(p, a) => "Lambda(" + p.name + ", " + show.shows(a) + ")"
+          case Apply(f, a)  =>
+            "Apply(" + show.shows(f) + ", " + show.shows(a) + ")"
+          case Let(n, v, i) =>
+            "Let(" + n.name + ", " + show.shows(v) + ", " + show.shows(i) + ")"
+        }
+    }
+
+  implicit val unzip = new Unzip[Exp] {
+    def unzip[A, B](f: Exp[(A, B)]) = (f.map(_._1), f.map(_._2))
+  }
+}
+
+class ExpSpec extends Spec {
+  implicit val arbExpInt: Arbitrary[Exp[Int]] = Exp.arbitrary(Arbitrary.arbInt)
+  // NB: These are just a sanity check that the data structure created for the
+  //     tests is lawful.
+  checkAll(equal.laws[Exp[Int]])
+  checkAll(traverse.laws[Exp])
+}

--- a/tests/src/test/scala/matryoshka/exp/package.scala
+++ b/tests/src/test/scala/matryoshka/exp/package.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import matryoshka.Recursive.ops._
+
+import java.lang.String
+import scala.{Boolean, Function, Int, None, Option, Predef, Symbol, Unit}
+import scala.collection.immutable.{List, Map, Nil}
+
+import scalaz._, Scalaz._
+
+package object exp {
+  def num(v: Int) = Fix[Exp](Num(v))
+  def mul(left: Fix[Exp], right: Fix[Exp]) = Fix[Exp](Mul(left, right))
+  def vari(v: Symbol) = Fix[Exp](Var(v))
+  def lam(param: Symbol, body: Fix[Exp]) = Fix[Exp](Lambda(param, body))
+  def ap(func: Fix[Exp], arg: Fix[Exp]) = Fix[Exp](Apply(func, arg))
+  def let(name: Symbol, v: Fix[Exp], inBody: Fix[Exp]) = Fix[Exp](Let(name, v, inBody))
+
+  val example1ƒ: Exp[Option[Int]] => Option[Int] = {
+    case Num(v)           => v.some
+    case Mul(left, right) => (left ⊛ right)(_ * _)
+    case Var(v)           => None
+    case Lambda(_, b)     => b
+    case Apply(func, arg) => None
+    case Let(_, _, i)     => i
+  }
+
+  def addOneOptƒ[T[_[_]]]: Exp[T[Exp]] => Option[Exp[T[Exp]]] = {
+    case Num(n) => Num(n+1).some
+    case _      => None
+  }
+
+  def addOneƒ[T[_[_]]]: Exp[T[Exp]] => Exp[T[Exp]] =
+    orOriginal(addOneOptƒ)
+
+  def simplifyƒ[T[_[_]]: Recursive]: Exp[T[Exp]] => Option[Exp[T[Exp]]] = {
+    case Mul(a, b) => (a.project, b.project) match {
+      case (Num(0), Num(_)) => Num(0).some
+      case (Num(1), Num(n)) => Num(n).some
+      case (Num(_), Num(0)) => Num(0).some
+      case (Num(n), Num(1)) => Num(n).some
+      case (_,      _)      => None
+    }
+    case _         => None
+  }
+
+  def addOneOrSimplifyƒ[T[_[_]]: Recursive]: Exp[T[Exp]] => Exp[T[Exp]] = {
+    case t @ Num(_)    => addOneƒ(t)
+    case t @ Mul(_, _) => repeatedly(simplifyƒ[T]).apply(t)
+    case t             => t
+  }
+
+  val MinusThree: Exp ~> Exp =
+    new (Exp ~> Exp) {
+      def apply[A](exp: Exp[A]): Exp[A] = exp match {
+        case Num(x) => Num(x-3)
+        case t      => t
+      }
+    }
+
+  val eval: Algebra[Exp, Int] = {
+    case Num(x)    => x
+    case Mul(x, y) => x*y
+    case _         => Predef.???
+  }
+
+  val findConstants: Exp[List[Int]] => List[Int] = {
+    case Num(x) => x :: Nil
+    case t      => t.fold
+  }
+
+  def extractFactors: Coalgebra[Exp, Int] = x =>
+    if (x > 2 && x % 2 == 0) Mul(2, x/2)
+    else Num(x)
+
+  def subst[T[_[_]]: Recursive](vars: Map[Symbol, T[Exp]], t: T[Exp]):
+      (Map[Symbol, T[Exp]], T[Exp]) = t.project match {
+    case Let(sym, value, body) => (vars + ((sym, value)), body)
+    case Var(sym)              => (vars, vars.get(sym).getOrElse(t))
+    case _                     => (vars, t)
+  }
+
+  // Evaluate as usual, but trap 0*0 as a special case
+  def peval[T[_[_]]: Recursive](t: Exp[(T[Exp], Int)]): Int = t match {
+    case Mul((Proj(Num(0)), _), (Proj(Num(0)), _)) => -1
+    case Mul((_           , x), (_,            y)) => x * y
+    case Num(x)                                    => x
+    case _                                         => Predef.???
+  }
+
+  def fact(x: Int): Exp[Fix[Exp] \/ Int] =
+    if (x > 1) Mul(-\/(num(x)), \/-(x-1))
+    else Num(x)
+
+  def extractFactorsM(x: Int): Option[Exp[Int]] =
+    if (x == 5) None else extractFactors(x).some
+
+  def strings(t: Exp[(Int, String)]): String = t match {
+    case Num(x) => x.toString
+    case Mul((x, xs), (y, ys)) =>
+      xs + " (" + x + ")" + ", " + ys + " (" + y + ")"
+    case _ => Predef.???
+  }
+
+  // NB: This is better done with cata, but we fake it here
+  def partialEval[T[_[_]]: Corecursive: Recursive]:
+      Exp[Cofree[Exp, T[Exp]]] => T[Exp] = t =>
+  t match {
+    case Mul(x, y) => (x.head.project, y.head.project) match {
+      case (Num(a), Num(b)) => Num[T[Exp]](a * b).embed
+      case _                => t.map(_.head).embed
+    }
+    case _ => t.map(_.head).embed
+  }
+
+  // FIXME: defining this as an algebra brings up the “cyclic aliasisng” issue
+  def extract2and3: Int => Exp[Free[Exp, Int]] = x =>
+  // factors all the way down
+  if (x > 2 && x % 2 == 0) Mul(Free.point(2), Free.point(x/2))
+  // factors once and then stops
+  else if (x > 3 && x % 3 == 0)
+    Mul(Free.liftF(Num(3)), Free.liftF(Num(x/3)))
+  else Num(x)
+}

--- a/tests/src/test/scala/matryoshka/exp2/Exp2.scala
+++ b/tests/src/test/scala/matryoshka/exp2/Exp2.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.exp2
+
+import matryoshka._
+
+import scala.Int
+
+import org.scalacheck._
+import org.specs2.scalaz._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+sealed trait Exp2[A]
+case class Const[A]()          extends Exp2[A]
+case class Num2[A](value: Int) extends Exp2[A]
+case class Single[A](a: A)     extends Exp2[A]
+
+object Exp2 {
+  implicit val arbitrary: Arbitrary ~> λ[α => Arbitrary[Exp2[α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Exp2[α]]]) {
+      def apply[α](arb: Arbitrary[α]): Arbitrary[Exp2[α]] =
+        Arbitrary(Gen.oneOf(
+          Gen.const(Const[α]),
+          Arbitrary.arbitrary[Int].map(Num2[α](_)),
+          arb.arbitrary.map(Single(_))))
+    }
+
+  def const = Fix[Exp2](Const())
+  def num2(v: Int) = Fix[Exp2](Num2(v))
+  def single(a: Fix[Exp2]) = Fix[Exp2](Single(a))
+
+  implicit val functor: Functor[Exp2] = new Functor[Exp2] {
+    def map[A, B](fa: Exp2[A])(f: A => B): Exp2[B] = fa match {
+      case Const()   => Const[B]()
+      case Num2(v)   => Num2[B](v)
+      case Single(a) => Single(f(a))
+    }
+  }
+
+  implicit val show: Show ~> λ[α => Show[Exp2[α]]] =
+    new (Show ~> λ[α => Show[Exp2[α]]]) {
+      def apply[α](show: Show[α]) =
+        Show.show {
+          case Const()   => "Const()"
+          case Num2(v)   => "Num2(" + v.shows + ")"
+          case Single(a) => "Single(" + show.shows(a) + ")"
+        }
+    }
+
+  implicit val equal: Equal ~> λ[α => Equal[Exp2[α]]] =
+    new (Equal ~> λ[α => Equal[Exp2[α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal[Exp2[α]] {
+          case (Const(), Const())       => true
+          case (Num2(v1), Num2(v2))     => v1 ≟ v2
+          case (Single(a1), Single(a2)) => eq.equal(a1, a2)
+          case _                        => false
+        }
+    }
+  implicit def equal2[A](implicit A: Equal[A]): Equal[Exp2[A]] = equal(A)
+}
+
+class Exp2Spec extends Spec {
+  implicit val arbExp2Int: Arbitrary[Exp2[Int]] = Exp2.arbitrary(Arbitrary.arbInt)
+  // NB: These are just a sanity check that the data structure created for the
+  //     tests is lawful.
+  checkAll(equal.laws[Exp2[Int]])
+  checkAll(functor.laws[Exp2])
+}


### PR DESCRIPTION
This is currently failing to compile, because it claims that “value generalize is not a member of Algebra[Exp,Int]”. I’m not sure why the `ToAlgebraOps` implicit is suddenly not being found. I moved the tests around, but it looks like all the imports and dependencies are in the right spot. If anyone can see the problem, please let me know.
