### PR TITLE
Fix broken and add missing prepromorphisms.

### DIFF
--- a/CHANGELOG/minor.md
+++ b/CHANGELOG/minor.md
@@ -1,0 +1,2 @@
+- add `prepro` and `gprepro`
+- fix signature & behavior of `transPrepro` and `transPostpro`

--- a/core/src/main/scala/matryoshka/FunctorT.scala
+++ b/core/src/main/scala/matryoshka/FunctorT.scala
@@ -63,11 +63,11 @@ import simulacrum.{typeclass, op}
   def transAna[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[F]]): T[G] =
     map(t)(f(_).map(transAna(_)(f)))
 
-  def transPrepro[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[G]] => G[T[G]])(g: F ~> F): T[G] =
-    map(t)(ft => f(g(ft.map(transPrepro(_)(f)(g)))))
+  def transPrepro[F[_]: Functor, G[_]: Functor](t: T[F])(e: F ~> F, f: F[T[G]] => G[T[G]]): T[G] =
+    map(t)(ft => f(ft ∘ (x => transPrepro(transCata[F, F](x)(e(_)))(e, f))))
 
-  def transPostpro[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[F]])(g: G ~> G): T[G] =
-    map(t)(ft => g(f(ft).map(transPostpro(_)(f)(g))))
+  def transPostpro[F[_]: Functor, G[_]: Functor](t: T[F])(e: G ~> G, f: F[T[F]] => G[T[F]]): T[G] =
+    map(t)(f(_) ∘ (x => transAna(transPostpro(x)(e, f))(e)))
 
   def transPara[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[(T[F], T[G])] => G[T[G]]):
       T[G] =

--- a/core/src/main/scala/matryoshka/Recursive.scala
+++ b/core/src/main/scala/matryoshka/Recursive.scala
@@ -69,6 +69,20 @@ import simulacrum.typeclass
       A =
     g(project(t) ∘ (x => (mutu(x)(g, f), mutu(x)(f, g))))
 
+  def prepro[F[_]: Functor, A](t: T[F])(e: F ~> F, f: F[A] => A)(implicit T: Corecursive[T]): A =
+    f(project(t) ∘ (x => prepro(cata[F, T[F]](x)(c => T.embed(e(c))))(e, f)))
+
+  def gprepro[F[_]: Functor, W[_]: Comonad, A](
+    t: T[F])(
+    k: DistributiveLaw[F, W], e: F ~> F, f: F[W[A]] => A)(
+    implicit T: Corecursive[T]):
+      A = {
+    def loop(t: T[F]): W[A] =
+      k(project(t) ∘ (x => loop(cata[F, T[F]](x)(c => T.embed(e(c)))).cojoin)) ∘ f
+
+    loop(t).copoint
+  }
+
   def histo[F[_]: Functor, A](t: T[F])(f: F[Cofree[F, A]] => A): A =
     gcata[F, Cofree[F, ?], A](t)(distHisto, f)
 

--- a/core/src/test/scala/matryoshka/spec.scala
+++ b/core/src/test/scala/matryoshka/spec.scala
@@ -350,31 +350,47 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
       }
     }
 
+    "prepro" should {
+      "multiply original with identity ~>" in {
+        mul(num(1), mul(num(12), num(8)))
+          .prepro(NaturalTransformation.refl[Exp], example1ƒ) must
+          equal(96.some)
+      }
+
+      "apply ~> repeatedly" in {
+        mul(num(1), mul(num(12), num(8))).prepro(MinusThree, example1ƒ) must
+          equal(-24.some)
+      }
+    }
+
     "transPrepro" should {
       "change literal with identity ~>" in {
-        num(1).transPrepro(addOneƒ)(NaturalTransformation.refl[Exp]) must equal(num(2))
+        num(1).transPrepro(NaturalTransformation.refl[Exp], addOneƒ) must equal(num(2))
       }
 
       "apply ~> in original space" in {
-        num(1).transPrepro(addOneƒ)(MinusThree) must equal(num(-1))
+        mul(num(1), mul(num(12), num(8))).transPrepro(MinusThree, addOneƒ) must
+          equal(mul(num(-1), mul(num(7), num(3))))
       }
 
       "apply ~> with change of space" in {
-        num(1).transPrepro(addOneExpExp2ƒ)(MinusThree) must equal(Exp2.num2(-1))
+        num(1).transPrepro(MinusThree, addOneExpExp2ƒ) must equal(Exp2.num2(2))
       }
     }
 
     "transPostpro" should {
       "change literal with identity ~>" in {
-        num(1).transPostpro(addOneƒ)(NaturalTransformation.refl[Exp]) must equal(num(2))
+        num(1).transPostpro(NaturalTransformation.refl[Exp], addOneƒ) must
+          equal(num(2))
       }
 
       "apply ~> in original space" in {
-        num(1).transPostpro(addOneƒ)(MinusThree) must equal(num(-1))
+        mul(num(1), mul(num(12), num(8))).transPostpro(MinusThree, addOneƒ) must
+          equal(mul(num(-1), mul(num(7), num(3))))
       }
 
       "apply ~> with change of space" in {
-        Exp2.num2(1).transPostpro(addOneExp2Expƒ)(MinusThree) must equal(num(-1))
+        Exp2.num2(1).transPostpro(MinusThree, addOneExp2Expƒ) must equal(num(2))
       }
     }
 


### PR DESCRIPTION
The behavior of `transPrepro` and `transPostpro` was wrong, only
applying the natural transformation to each node once, when it should
apply them to all deeper nodes before/after each node is processed.

Sorry for any confusion, @alissapajer!