### PR TITLE
A few additions around fixed-point type aliases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: scala
 scala:
-- 2.11.7
+  - 2.11.8
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
 sudo: false
 script:
   - sbt checkHeaders

--- a/CHANGELOG/feature.md
+++ b/CHANGELOG/feature.md
@@ -1,0 +1,3 @@
+- add type aliases for various types (like `Free` and `Cofree`) in a new package to show the equivalences, and start moving toward fixed-point alternatives
+- add `AlgebraIso` to make isomorphic algebras explicit.
+- a few new pattern functors (in their own package) – `CoEnv`, `ListF`, `Diff`, and `PotentialFailure`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Generalized folds, unfolds, and traversals for fixed point data structures in Sc
 - [Efficient Nanopass Compilers using Cats and Matryoshka](https://github.com/sellout/recursion-scheme-talk/blob/master/nanopass-compiler-talk.org) – Greg Pfeil’s talk on this library (and some other things)
 - [Fix Haskell (by eliminating recursion)](https://github.com/sellout/recursion-scheme-talk/blob/master/recursion-scheme-talk.org) – Greg Pfeil’s talk on recursion schemes in Haskell
 
+## Usage
+
+To use Matryoshka, the following import should bring in pretty much everything:
+
+```scala
+import matryoshka._, Recursive.ops._, TraverseT.ops._
+```
+
+Also, there are a number of implicits that scalac has trouble finding. Adding @milessabin’s [SI-2712 fix compiler plugin](https://github.com/milessabin/si2712fix-plugin) will simplify a ton of Matryoshka-related code.
+
 ## Introduction
 
 This library is predicated on the idea of rewriting your recursive data structures, replacing the recursive type reference with a fresh type parameter.
@@ -66,7 +76,8 @@ val eval: Expr[Long] => Long = {
 }
 
 def someExpr[T[_[_]]: Corecursive]: T[Expr] =
-  Mul(Num(2).embed, Mul(Num(3).embed, Num(4).embed).embed).embed
+  Mul(Num[T[Expr]](2).embed, Mul(Num[T[Expr]](3).embed,
+      Num[T[Expr]](4).embed).embed).embed
 
 someExpr[Mu].cata(eval) // ⇒ 24
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ lazy val standardSettings = Seq(
     "JBoss repository" at "https://repository.jboss.org/nexus/content/repositories/",
     "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
     "bintray/non" at "http://dl.bintray.com/non/maven"),
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1"),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-
+  addCompilerPlugin("org.spire-math" %% "kind-projector"   % "0.7.1"),
+  addCompilerPlugin("org.scalamacros" % "paradise"         % "2.1.0" cross CrossVersion.full),
+  addCompilerPlugin("com.milessabin"  % "si2712fix-plugin" % "1.2.0" cross CrossVersion.full),
   ScoverageKeys.coverageHighlighting := true,
 
   scalacOptions ++= Seq(
@@ -55,17 +55,21 @@ lazy val standardSettings = Seq(
   console <<= console in Test, // console alias test:console
 
   libraryDependencies ++= {
+    val monocleVersion = "1.2.1"
     val scalazVersion = "7.2.1"
     // Latest version built against scalacheck 1.12.5
     val specs2Version = "3.7"
     Seq(
-      "com.github.mpilquist" %% "simulacrum"             % "0.7.0"       % "compile, test",
-      "org.scalaz"        %% "scalaz-core"               % scalazVersion % "compile, test",
-      "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion % "test",
-      "org.specs2"        %% "specs2-core"               % specs2Version % "test" force(),
-      "org.specs2"        %% "specs2-scalacheck"         % specs2Version % "test" force(),
+      "org.typelevel"              %% "discipline"       % "0.4"          % "test",
+      "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion % "compile, test",
+      "com.github.julien-truffaut" %% "monocle-law"      % monocleVersion % "test",
+      "com.github.mpilquist" %% "simulacrum"             % "0.7.0"        % "compile, test",
+      "org.scalaz"        %% "scalaz-core"               % scalazVersion  % "compile, test",
+      "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion  % "test",
+      "org.specs2"        %% "specs2-core"               % specs2Version  % "test" force(),
+      "org.specs2"        %% "specs2-scalacheck"         % specs2Version  % "test" force(),
       // `scalaz-scalacheck-binding` is built with `scalacheck` 1.12.5 so we are stuck with that version
-      "org.scalacheck"    %% "scalacheck"                % "1.12.5"      % "test" force())
+      "org.scalacheck"    %% "scalacheck"                % "1.12.5"       % "test" force())
   },
 
   licenses += ("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0")),

--- a/core/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/src/main/scala/matryoshka/Corecursive.scala
@@ -97,7 +97,3 @@ import simulacrum.typeclass
     f(a).flatMap(_.traverse(loop)) ∘ (embed(_))
   }
 }
-
-sealed class CorecursiveOps[T[_[_]], F[_]](self: F[T[F]])(implicit T: Corecursive[T]) {
-  def embed(implicit F: Functor[F]): T[F] = T.embed(self)
-}

--- a/core/src/main/scala/matryoshka/Merge.scala
+++ b/core/src/main/scala/matryoshka/Merge.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scala.{inline, None, Option, Unit}
+
+import simulacrum.typeclass
+import scalaz._, Scalaz._
+
+/** Like `Zip`, but it can fail to merge, so it’s much more general.
+  */
+@typeclass trait Merge[F[_]] {
+  // TODO[simulacrum#57]: `fa` should be lazy
+  def merge[A, B](fa: F[A], fb: => F[B]): Option[F[(A, B)]]
+
+  // TODO[simulacrum#57]: `fa` should be lazy
+  def mergeWith[A, B, C, D](
+    fa: F[A], fb: => F[B])(g: (A, B) => D)(
+    implicit F: Functor[F]):
+      Option[F[D]] =
+    merge(fa, fb).map(_ ∘ g.tupled)
+}
+
+object Merge {
+  implicit def fromTraverse[F[_]: Traverse](implicit E: Equal[F[Unit]]):
+      Merge[F] =
+    new Merge[F] {
+      def merge[A, B](fa: F[A], fb: => F[B]): Option[F[(A, B)]] =
+        if (fa.void ≟ fb.void)
+          fa.zipWithL(fb)((a, b) => b ∘ ((a, _))).sequence
+        else None
+    }
+}

--- a/core/src/main/scala/matryoshka/cofree.scala
+++ b/core/src/main/scala/matryoshka/cofree.scala
@@ -39,7 +39,7 @@ trait CofreeInstances {
 
   implicit def cofreeShow[F[_], A: Show](implicit F: (Show ~> λ[α => Show[F[α]]])):
       Show[Cofree[F, A]] =
-        Show.shows(cof => "(" + cof.head.show + ", " + F(cofreeShow).shows(cof.tail) + ")")
+        Show.shows(cof => "(" + cof.head.show + ", " + cof.tail.shows + ")")
 }
 
 object cofree extends CofreeInstances

--- a/core/src/main/scala/matryoshka/instances/fixedpoint/package.scala
+++ b/core/src/main/scala/matryoshka/instances/fixedpoint/package.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.instances
+
+import matryoshka._, Recursive.ops._
+import matryoshka.patterns._
+
+import scala.{Boolean, Int, Option}
+
+import scalaz._, Scalaz._
+
+/** This package provides instances of various common data structures
+  * implemented explicitly as fixed-points.
+  */
+package object fixedpoint {
+  type Free[F[_], A] = Mu[CoEnv[A, F, ?]]
+  type Cofree[F[_], A] = Mu[EnvT[A, F, ?]]
+  type List[A] = Mu[ListF[A, ?]]
+
+  object List {
+    def apply[A](elems: A*) =
+      elems.ana[Mu, ListF[A, ?]](ListF.seqIso[A].reverseGet)
+
+    def fill[A](n: Int)(elem: => A): List[A] =
+      n.ana[Mu, ListF[A, ?]](r => if (r > 0) ConsF(elem, r - 1) else NilF())
+  }
+
+  implicit class ListOps[A](self: Mu[ListF[A, ?]]) {
+    def length: Int = self.cata(size) - 1
+  }
+
+  implicit class RecListFOps[T[_[_]]: Recursive, A](self: T[ListF[A, ?]]) {
+    def headOption: Option[A]              = self.project.headOption
+    def tailOption: Option[T[ListF[A, ?]]] = self.project.tailOption
+  }
+
+  /** A lazy (potentially-infinite) list.
+    */
+  type Colist[A] = Nu[ListF[A, ?]]
+
+  /** A true stream – infinite.
+    */
+  type Stream[A] = Nu[(A, ?)]
+
+  implicit class StreamOps[A](self: Nu[(A, ?)]) {
+    def head: A = self.project._1
+    def tail: Nu[(A, ?)] = self.project._2
+    def drop(n: Int): Nu[(A, ?)] =
+      if (n > 0) tail.drop(n - 1) else self
+    def take(n: Int): Mu[ListF[A, ?]] =
+      (n, self).ana[Mu, ListF[A, ?]] {
+        case (r, stream) if (r > 0) => ConsF(stream.head, (r - 1, stream.tail))
+        case (_, _)                 => NilF()
+      }
+  }
+
+  /** Encodes a function that may diverge.
+    */
+  type Partial[A] = Nu[A \/ ?]
+
+  object Partial {
+    def now[A](a: A): Partial[A] = a.left[Nu[A \/ ?]].embed
+    def later[A](partial: Partial[A]): Partial[A] = partial.right[A].embed
+
+    /** Canonical function that diverges.
+      */
+    def never[A]: Partial[A] = ().ana[Nu, A \/ ?](_.right)
+
+    implicit def monad: Monad[Partial] = new Monad[Partial] {
+      def point[A](a: => A) = now(a)
+      def bind[A, B](fa: Partial[A])(f: A => Partial[B]) =
+        fa.project.fold(f, l => later(bind(l)(f)))
+    }
+
+    /** This instance is not implicit, because it potentially runs forever.
+      */
+    def equal[A: Equal]: Equal[Partial[A]] =
+      Equal.equal((a, b) => (a ≈ b).unsafePerformSync)
+
+    def fromOption[A](opt: Option[A]): Partial[A] = opt.fold(never[A])(now)
+    def fromPartialFunction[A, B](pf: scala.PartialFunction[A, B]):
+        A => Partial[B] =
+      pf.lift ⋙ fromOption
+  }
+
+  implicit class PartialOps[A](self: Nu[A \/ ?]) {
+    import Partial._
+
+    def step: A \/ Partial[A] = self.project
+
+    /** Returns `left` if the result was found within the given number of steps.
+      */
+    def runFor(steps: Int): A \/ Partial[A] =
+      if (steps <= 0) step else step >>= (_.runFor(steps - 1))
+
+    /** Run to completion (if it completes).
+      */
+    def unsafePerformSync: A = self.project.fold(x => x, _.unsafePerformSync)
+
+    /** If two `Partial`s eventually have the same value, then they are
+      * equivalent.
+      */
+    def ≈(that: Partial[A])(implicit A: Equal[A]): Partial[Boolean] =
+      // NB: could be defined as `(self ⊛ that)(_ ≟ _)`
+      (self, that).ana[Nu, Boolean \/ ?](_.bimap(_.project, _.project) match {
+        case (-\/(a1), -\/(a2)) => (a1 ≟ a2).left
+        case (\/-(l1), -\/(a2)) => (l1,      now(a2)).right
+        case (-\/(a1), \/-(l2)) => (now(a1), l2).right
+        case (\/-(l1), \/-(l2)) => (l1,      l2).right
+      })
+  }
+}

--- a/core/src/main/scala/matryoshka/patterns/CoEnv.scala
+++ b/core/src/main/scala/matryoshka/patterns/CoEnv.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._
+
+import scalaz._, Scalaz._
+
+/** The pattern functor for Free. */
+final case class CoEnv[E, F[_], A](run: E \/ F[A])
+object CoEnv extends CoEnvInstances {
+  def coEnv[E, F[_], A](v: E \/ F[A]): CoEnv[E, F, A] = CoEnv(v)
+
+  def freeIso[E, F[_]: Functor] = AlgebraIso[CoEnv[E, F, ?], Free[F, E]](
+    coe => coe.run.fold(_.point[Free[F, ?]], Free.roll))(
+    fr => CoEnv(fr.fold(_.left, _.right)))
+}
+
+sealed abstract class CoEnvInstances extends CoEnvInstances0 {
+  implicit def equal[E: Equal, F[_]](
+    implicit F: Equal ~> λ[α => Equal[F[α]]]):
+      Equal ~> λ[α => Equal[CoEnv[E, F, α]]] =
+    new (Equal ~> λ[α => Equal[CoEnv[E, F, α]]]) {
+      def apply[α](arb: Equal[α]) = {
+        Equal.equal((a, b) => (a.run, b.run) match {
+          case (-\/(e1), -\/(e2)) => e1 ≟ e2
+          case (\/-(f1), \/-(f2)) => F(arb).equal(f1, f2)
+          case (_,       _)       => false
+        })
+      }
+    }
+
+  // TODO: Need to have lower-prio instances of Functor and Foldable, with
+  //       corresponding constraints on F.
+  implicit def traverse[F[_]: Traverse, A]: Traverse[CoEnv[A, F, ?]] =
+    new Traverse[CoEnv[A, F, ?]] {
+      def traverseImpl[G[_]: Applicative, R, B](
+        fa: CoEnv[A, F, R])(
+        f: R => G[B]):
+          G[CoEnv[A, F, B]] =
+        fa.run.traverse(_.traverse(f)).map(CoEnv(_))
+    }
+
+  // TODO: write a test to ensure the two monad instances are identical
+  implicit def monadCo[F[_]: Applicative: Comonad, A]: Monad[CoEnv[A, F, ?]] =
+    new Monad[CoEnv[A, F, ?]] {
+      def bind[B, C](fa: CoEnv[A, F, B])(f: (B) ⇒ CoEnv[A, F, C]) =
+        fa.run.fold(a => CoEnv(a.left), fb => f(fb.copoint))
+      def point[B](x: => B) = CoEnv(x.point[F].right)
+    }
+}
+
+sealed abstract class CoEnvInstances0 {
+  implicit def monad[F[_]: Monad: Traverse, A]: Monad[CoEnv[A, F, ?]] =
+    new Monad[CoEnv[A, F, ?]] {
+      def bind[B, C](fa: CoEnv[A, F, B])(f: (B) ⇒ CoEnv[A, F, C]) =
+        CoEnv(fa.run.fold(_.left, _.traverse[CoEnv[A, F, ?], C](f).run.map(_.join)))
+      def point[B](x: => B) = CoEnv(x.point[F].right)
+    }
+}

--- a/core/src/main/scala/matryoshka/patterns/Diff.scala
+++ b/core/src/main/scala/matryoshka/patterns/Diff.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._
+
+import scala.Unit
+
+import scalaz._, Scalaz._
+
+/** Represents diffs of recursive data structures.
+  */
+sealed trait Diff[T[_[_]], F[_], A]
+final case class Same[T[_[_]], F[_], A](ident: T[F]) extends Diff[T, F, A]
+final case class Similar[T[_[_]], F[_], A](ident: F[A]) extends Diff[T, F, A]
+final case class Different[T[_[_]], F[_], A](left: T[F], right: T[F])
+    extends Diff[T, F, A]
+final case class LocallyDifferent[T[_[_]], F[_], A](left: F[A], right: F[Unit])
+    extends Diff[T, F, A]
+final case class Inserted[T[_[_]], F[_], A](right: F[A])
+    extends Diff[T, F, A]
+final case class Deleted[T[_[_]], F[_], A](left: F[A])
+    extends Diff[T, F, A]
+final case class Added[T[_[_]], F[_], A](right: T[F])
+    extends Diff[T, F, A]
+final case class Removed[T[_[_]], F[_], A](left: T[F])
+    extends Diff[T, F, A]
+
+object Diff extends DiffInstances
+
+sealed abstract class DiffInstances extends DiffInstances0 {
+  // TODO: implement low-prio Foldable with looser constraint on F
+  implicit def traverse[T[_[_]], F[_]: Traverse]: Traverse[Diff[T, F, ?]] =
+    new Traverse[Diff[T, F, ?]] {
+      def traverseImpl[G[_], A, B](
+        fa: Diff[T, F, A])(
+        f: A => G[B])(
+        implicit G: Applicative[G]):
+          G[Diff[T, F, B]] =
+        fa match {
+          case Same(ident) => G.point(Same(ident))
+          case Similar(ident) => ident.traverse(f) ∘ (Similar(_))
+          case Different(left, right) =>
+            G.point(Different(left, right))
+          case LocallyDifferent(left, right) =>
+            left.traverse(f) ∘ (LocallyDifferent(_, right))
+          case Inserted(right) => right.traverse(f) ∘ (Inserted(_))
+          case Deleted(left) => left.traverse(f) ∘ (Deleted(_))
+          case Added(right) => G.point(Added(right))
+          case Removed(left) => G.point(Removed(left))
+        }
+    }
+
+  implicit def equal[T[_[_]], F[_]](implicit T: Equal[T[F]], F: Equal ~> λ[α => Equal[F[α]]]):
+      Equal ~> λ[α => Equal[Diff[T, F, α]]] =
+    new (Equal ~> λ[α => Equal[Diff[T, F, α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal((a, b) => (a, b) match {
+          case (Same(i1), Same(i2)) => T.equal(i1, i2)
+          case (Similar(i1), Similar(i2)) => F(eq).equal(i1, i2)
+          case (Different(l1, r1), Different(l2, r2)) =>
+            T.equal(l1, l2) && T.equal(r1, r2)
+          case (LocallyDifferent(l1, r1), LocallyDifferent(l2, r2)) =>
+            F(eq).equal(l1, l2) && F(Equal[Unit]).equal(r1, r2)
+          case (Inserted(r1), Inserted(r2)) => F(eq).equal(r1, r2)
+          case (Deleted(l1), Deleted(l2)) => F(eq).equal(l1, l2)
+          case (Added(r1), Added(r2)) => T.equal(r1, r2)
+          case (Removed(l1), Removed(l2)) => T.equal(l1, l2)
+          case (_, _) => false
+        })
+    }
+
+  implicit def show[T[_[_]], F[_]: Functor: Foldable](implicit T: Show[T[F]], F: Show ~> λ[α => Show[F[α]]]):
+      Show ~> λ[α => Show[Diff[T, F, α]]] =
+    new (Show ~> λ[α => Show[Diff[T, F, α]]]) {
+      def apply[α](s: Show[α]) = Show.show {
+        case Same(_) => Cord("...")
+        case Similar(x) => F(s).show(x)
+        case Different(l, r) =>
+          Cord("vvvvvvvvv left  vvvvvvvvv\n") ++
+            T.show(l) ++
+            Cord("\n=========================\n") ++
+            T.show(r) ++
+            Cord("\n^^^^^^^^^ right ^^^^^^^^^")
+        case Inserted(x) =>  Cord("+++> ") ++ F(s).show(x)
+        case Deleted(x) => Cord("<--- ") ++ F(s).show(x)
+        case Added(x) => Cord("+++> ") ++ T.show(x)
+        case Removed(x) => Cord("<--- ") ++ T.show(x)
+        case LocallyDifferent(l, r) =>
+          F(s).show(l) ++ " <=/=> " ++ F(Show[Unit]).show(r)
+      }
+    }
+}
+
+sealed abstract class DiffInstances0 {
+  implicit def functor[T[_[_]], F[_]: Functor]: Functor[Diff[T, F, ?]] =
+    new Functor[Diff[T, F, ?]] {
+      def map[A, B](fa: Diff[T, F, A])(f: A => B): Diff[T, F, B] =
+        fa match {
+          case Same(ident)                   => Same(ident)
+          case Similar(ident)                => Similar(ident ∘ f)
+          case Different(left, right)        => Different(left, right)
+          case LocallyDifferent(left, right) =>
+            LocallyDifferent(left ∘ f, right)
+          case Inserted(right)               => Inserted(right ∘ f)
+          case Deleted(left)                 => Deleted(left ∘ f)
+          case Added(right)                  => Added(right)
+          case Removed(left)                 => Removed(left)
+        }
+    }
+}

--- a/core/src/main/scala/matryoshka/patterns/Diffable.scala
+++ b/core/src/main/scala/matryoshka/patterns/Diffable.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._
+
+import scala.{inline, Option}
+
+import scalaz._, Scalaz._
+import simulacrum.typeclass
+
+@typeclass trait Diffable[F[_]] { self =>
+  def diffImpl[T[_[_]]: Recursive: Corecursive](l: T[F], r: T[F]):
+      Option[DiffT[T, F]]
+
+  /** Useful when a case class has a `List[A]` that isn’t the final `A`. This is
+    * because the normal comparison just walks over the children of the functor,
+    * so if the lists are different lengths, the default behavior will be
+    * confusing.
+    * Currently also useful when the only list _is_ the final parameter, because
+    * it allows you to explicitly use `Similar` rather than `LocallyDifferent`.
+    */
+  def diffTraverse[T[_[_]]: Recursive: Corecursive, G[_]: Traverse](
+    left: G[T[F]], right: G[T[F]])(
+    implicit FF: Functor[F], FoldF: Foldable[F], FM: Merge[F]):
+      G[DiffT[T, F]] =
+    if (left.toList.length < right.toList.length)
+      left.zipWithR(right)((l, r) =>
+        l.fold(
+          CorecursiveOps[T, Diff[T, F, ?]](Added(r)).embed)(
+          // NB: needed to use `Recursive[T]` to please Scaladoc
+          Recursive[T].paraMerga(_, r)(diff(Recursive[T], Corecursive[T], self, FF, FoldF))))
+    else
+      left.zipWithL(right)((l, r) =>
+        r.fold(
+          CorecursiveOps[T, Diff[T, F, ?]](Removed(l)).embed)(
+          // NB: needed to use `Recursive[T]` to please Scaladoc
+          Recursive[T].paraMerga(l, _)(diff(Recursive[T], Corecursive[T], self, FF, FoldF))))
+
+  // TODO: create something like Equals, but that overrides G[F[_]] (where G
+  //       implements Traverse) to always be equal. This should allow us to
+  //       distinguish between, say, two things containing a List[F[_]] that
+  //       only differ on the length of the list. So we can make them `Similar`
+  //       rather than `LocallyDifferent`.
+
+  def localDiff[T[_[_]]: Recursive: Corecursive](
+    left: F[T[F]], right: F[T[F]])(
+    implicit FT: Traverse[F], FM: Merge[F]):
+      DiffT[T, F] =
+    CorecursiveOps[T, Diff[T, F, ?]](LocallyDifferent[T, F, DiffT[T, F]](diffTraverse(left, right), right.void)).embed
+}

--- a/core/src/main/scala/matryoshka/patterns/EnvT.scala
+++ b/core/src/main/scala/matryoshka/patterns/EnvT.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.patterns
+
+import matryoshka._
 
 import scalaz._, Scalaz._
 
-/**
- * This is the transformer for the (,) comonad.
- */
+/** This is the transformer for the (,) comonad.
+  */
 final case class EnvT[E, W[_], A](run: (E, W[A])) { self =>
   import EnvT._
 
@@ -56,6 +57,10 @@ sealed abstract class EnvTInstances extends EnvTInstances0 {
 
 trait EnvTFunctions {
   def envT[E, W[_], A](v: (E, W[A])): EnvT[E, W, A] = EnvT(v)
+
+  def cofreeIso[E, W[_]] = AlgebraIso[EnvT[E, W, ?], Cofree[W, E]](
+    et => Cofree(et.ask, et.lower))(
+    cof => EnvT((cof.head, cof.tail)))
 }
 
 //

--- a/core/src/main/scala/matryoshka/patterns/ListF.scala
+++ b/core/src/main/scala/matryoshka/patterns/ListF.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._
+
+import scala.{List, Nil, None, Option, Seq, ::}
+
+import scalaz._, Scalaz._
+
+sealed trait ListF[A, B] {
+  def headOption: Option[A] = this match {
+    case ConsF(h, _) => h.some
+    case NilF()      => None
+  }
+
+  def tailOption: Option[B] = this match {
+    case ConsF(_, t) => t.some
+    case NilF()      => None
+  }
+}
+final case class ConsF[A, B](car: A, cdr: B) extends ListF[A, B]
+final case class NilF[A, B]() extends ListF[A, B]
+
+object ListF {
+  def listIso[A] = AlgebraIso[ListF[A, ?], List[A]] {
+    case ConsF(h, t) => h :: t
+    case NilF()      => Nil
+  } {
+    case h :: t => ConsF(h, t)
+    case Nil    => NilF()
+  }
+
+  /** Because sometimes you have to deal with `_*`.
+    */
+  def seqIso[A] = AlgebraIso[ListF[A, ?], Seq[A]] {
+    case ConsF(h, t) => h +: t
+    case NilF()      => Seq.empty
+  } (s => s.headOption.fold[ListF[A, Seq[A]]](NilF())(ConsF(_, s.tail)))
+
+  implicit def equal[A: Equal, B]: Equal ~> λ[β => Equal[ListF[A, β]]] =
+    new (Equal ~> λ[β => Equal[ListF[A, β]]]) {
+      def apply[β](eq: Equal[β]) = Equal.equal((a, b) => (a, b) match {
+        case (ConsF(h1, t1), ConsF(h2, t2)) => h1 ≟ h2 && eq.equal(t1, t2)
+        case (NilF(),        NilF())        => true
+        case (_,             _)             => false
+      })
+    }
+
+  implicit def show[A: Show, B]: Show ~> λ[β => Show[ListF[A, β]]] =
+    new (Show ~> λ[β => Show[ListF[A, β]]]) {
+      def apply[β](show: Show[β]) = Show.show {
+        case ConsF(h, t) => h.show ++ Cord("::") ++ show.show(t)
+        case NilF()      => Cord("nil")
+      }
+    }
+
+  implicit def bitraverse: Bitraverse[ListF] = new Bitraverse[ListF] {
+      def bitraverseImpl[G[_], A, B, C, D](
+        fab: ListF[A, B])(
+        f: A ⇒ G[C], g: B ⇒ G[D])(
+        implicit G: Applicative[G]) =
+        fab match {
+          case NilF()        => G.point(NilF())
+          case ConsF(a, b)        => (f(a) ⊛ g(b))(ConsF(_, _))
+        }
+    }
+
+  implicit def traverse[A]: Traverse[ListF[A, ?]] = bitraverse.rightTraverse[A]
+}

--- a/core/src/main/scala/matryoshka/patterns/PotentialFailure.scala
+++ b/core/src/main/scala/matryoshka/patterns/PotentialFailure.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import scalaz._, Scalaz._
+
+/** Generally similar to CoEnv (Free), this has an additional `success` case
+  * that indicates there’s no failure down to the leaves.
+  */
+sealed trait PotentialFailure[T[_[_]], F[_], E, A]
+final case class Success[T[_[_]], F[_], E, A] private[patterns](v: T[F])
+    extends PotentialFailure[T, F, E, A]
+/** Akin to Free.point */
+final case class Failure[T[_[_]], F[_], E, A] private[patterns](e: E)
+    extends PotentialFailure[T, F, E, A]
+/** Akin to Free.roll */
+final case class PartialFailure[T[_[_]], F[_], E, A] private[patterns](v: F[A])
+    extends PotentialFailure[T, F, E, A]
+
+object PotentialFailure {
+  implicit def potentialFailureEqual[T[_[_]], F[_], E: Equal](
+    implicit F: Equal ~> λ[α => Equal[F[α]]], T: Equal[T[F]]):
+      Equal ~> λ[α => Equal[PotentialFailure[T, F, E, α]]] =
+    new (Equal ~> λ[α => Equal[PotentialFailure[T, F, E, α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal {
+          case (Success(v1),        Success(v2))        => T.equal(v1, v2)
+          case (Failure(e1),        Failure(e2))        => e1 ≟ e2
+          case (PartialFailure(v1), PartialFailure(v2)) => F(eq).equal(v1, v2)
+          case (_,                  _)                  => false
+        }
+    }
+
+
+  // TODO: implement low-prio Bifunctor and Bifoldable with looser constraint on F
+  implicit def bitraverse[T[_[_]], F[_]: Traverse]:
+      Bitraverse[PotentialFailure[T, F, ?, ?]] =
+    new Bitraverse[PotentialFailure[T, F, ?, ?]] {
+      def bitraverseImpl[G[_], A, B, C, D](
+        fab: PotentialFailure[T, F, A, B])(
+        f: A ⇒ G[C], g: B ⇒ G[D])(
+        implicit G: Applicative[G]) =
+        fab match {
+          case Success(v)        => G.point(Success(v))
+          case Failure(e)        => f(e) ∘ (Failure(_))
+          case PartialFailure(v) => v.traverse(g) ∘ (PartialFailure(_))
+        }
+    }
+
+  implicit def traverse[T[_[_]], F[_]: Traverse, E]:
+      Traverse[PotentialFailure[T, F, E, ?]] =
+    bitraverse[T, F].rightTraverse[E]
+}

--- a/core/src/main/scala/matryoshka/patterns/package.scala
+++ b/core/src/main/scala/matryoshka/patterns/package.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scala.Option
+
+import scalaz._, Scalaz._, Leibniz._
+
+package object patterns {
+  // These aliases are because these functors require a higher-order functor as
+  // a parameter, and it’s likely to be the same as the “outer” one.
+  // NB: Still not sure they’re a good idea.
+
+  type DiffT[T[_[_]], F[_]] = T[Diff[T, F, ?]]
+  type PotentialFailureT[T[_[_]], F[_], E] = T[PotentialFailure[T, F, E, ?]]
+
+  def diff[T[_[_]]: Recursive: Corecursive, F[_]: Diffable: Functor: Foldable]:
+      (T[F], T[F], Option[F[DiffT[T, F]]]) => DiffT[T, F] =
+    ((l, r, merged) =>
+      merged.fold(
+        Diffable[F].diffImpl(l, r).getOrElse(CorecursiveOps[T, Diff[T, F, ?]](Different[T, F, DiffT[T, F]](l, r)).embed))(
+        merged => {
+          val children = merged.toList
+          CorecursiveOps[T, Diff[T, F, ?]](
+            if (children.length ≟ children.collect { case Same(_) => () }.length)
+              Same[T, F, DiffT[T, F]](l)
+            else Similar(merged)).embed
+        }))
+}

--- a/core/src/test/scala/matryoshka/example/Example.scala
+++ b/core/src/test/scala/matryoshka/example/Example.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.example
+
+import matryoshka._, Recursive.ops._
+import matryoshka.helpers._
+import matryoshka.patterns._
+import matryoshka.specs2.scalacheck.CheckAll
+
+import java.lang.String
+import scala.{Int, List, None, Option}
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.scalacheck.ScalazProperties._
+
+sealed trait Example[A]
+case class Empty[A]()                                   extends Example[A]
+case class NonRec[A](a: String, b: Int)                 extends Example[A]
+case class SemiRec[A](a: Int, b: A)                     extends Example[A]
+case class MultiRec[A](a: A, b: A)                      extends Example[A]
+case class OneList[A](l: List[A])                       extends Example[A]
+case class TwoLists[A](first: List[A], second: List[A]) extends Example[A]
+
+object Example {
+  implicit val traverse: Traverse[Example] = new Traverse[Example] {
+    def traverseImpl[G[_], A, B](fa: Example[A])(f: A => G[B])(
+      implicit G: Applicative[G]):
+        G[Example[B]] = fa match {
+      case Empty()        => G.point(Empty())
+      case NonRec(a, b)   => G.point(NonRec(a, b))
+      case SemiRec(a, b)  => f(b).map(SemiRec(a, _))
+      case MultiRec(a, b) => (f(a) ⊛ f(b))(MultiRec(_, _))
+      case OneList(a)     => a.traverse(f) ∘ (OneList(_))
+      case TwoLists(a, b) => (a.traverse(f) ⊛ b.traverse(f))(TwoLists(_, _))
+    }
+  }
+
+  implicit val equal: Equal ~> λ[α => Equal[Example[α]]] =
+    new (Equal ~> λ[α => Equal[Example[α]]]) {
+      def apply[α](eq: Equal[α]) = Equal.equal((a, b) => {
+        implicit val ieq = eq
+          (a, b) match {
+          case (Empty(),          Empty())          => true
+          case (NonRec(s1, i1),   NonRec(s2, i2))   => s1 ≟ s2 && i1 ≟ i2
+          case (SemiRec(i1, a1),  SemiRec(i2, a2))  =>
+            i1 ≟ i2 && eq.equal(a1, a2)
+          case (MultiRec(a1, b1), MultiRec(a2, b2)) =>
+            eq.equal(a1, a2) && eq.equal(b1, b2)
+          case (OneList(l),       OneList(r))       => l ≟ r
+          case (TwoLists(l1, l2), TwoLists(r1, r2)) => l1 ≟ r1 && l2 ≟ r2
+          case (_,                _)                => false
+        }
+      })
+    }
+
+  implicit val show: Show ~> λ[α => Show[Example[α]]] =
+    new (Show ~> λ[α => Show[Example[α]]]) {
+      def apply[α](s: Show[α]) = {
+        implicit val is = s
+        Show.show {
+          case Empty()          => Cord("Empty()")
+          case NonRec(s2, i2)   =>
+            Cord("NonRec(" + s2.shows + ", " + i2.shows + ")")
+          case SemiRec(i2, a2)   =>
+            Cord("SemiRec(") ++ i2.show ++ Cord(", ") ++ s.show(a2) ++ Cord(")")
+          case MultiRec(a2, b2) =>
+            Cord("MultiRec(") ++ s.show(a2) ++ Cord(", ") ++ s.show(b2) ++ Cord(")")
+          case OneList(r)       => Cord("OneList(") ++ r.show ++ Cord(")")
+          case TwoLists(r1, r2) =>
+            Cord("TwoLists(") ++ r1.show ++ Cord(", ") ++ r2.show ++ Cord(")")
+        }
+      }
+    }
+
+  implicit val diffable: Diffable[Example] = new Diffable[Example] {
+    def diffImpl[T[_[_]]: Recursive: Corecursive](l: T[Example], r: T[Example]):
+        Option[DiffT[T, Example]] =
+      (l.project, r.project) match {
+        case (l @ Empty(),        r @ Empty())        => localDiff(l, r).some
+        case (l @ NonRec(_, _),   r @ NonRec(_, _))   => localDiff(l, r).some
+        case (l @ SemiRec(_, _),  r @ SemiRec(_, _))  => localDiff(l, r).some
+        case (l @ MultiRec(_, _), r @ MultiRec(_, _)) => localDiff(l, r).some
+        case (OneList(l),         OneList(r))         =>
+          CorecursiveOps[T, Diff[T, Example, ?]](Similar(OneList[DiffT[T, Example]](diffTraverse(l, r)))).embed.some
+        case (TwoLists(l1, l2),   TwoLists(r1, r2))   =>
+          CorecursiveOps[T, Diff[T, Example, ?]](Similar(TwoLists[DiffT[T, Example]](diffTraverse(l1, r1), diffTraverse(l2, r2)))).embed.some
+        case (_,                  _)                  => None
+      }
+  }
+
+  implicit val arbitrary: Arbitrary ~> λ[α => Arbitrary[Example[α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Example[α]]]) {
+      def apply[α](arb: Arbitrary[α]) =
+        Arbitrary(Gen.sized(size =>
+          Gen.oneOf(
+            Empty[α]().point[Gen],
+            (Arbitrary.arbitrary[String] ⊛ Arbitrary.arbitrary[Int])(
+              NonRec[α](_, _)),
+            (Arbitrary.arbitrary[Int] ⊛ arb.arbitrary)(SemiRec(_, _)),
+            (arb.arbitrary ⊛ arb.arbitrary)(MultiRec(_, _)),
+            Gen.listOfN(size, arb.arbitrary).map(OneList(_)),
+            (Gen.listOfN(size / 2, arb.arbitrary) ⊛ Gen.listOfN(size / 2, arb.arbitrary))(
+              TwoLists(_, _)))
+        ))
+    }
+}
+
+class ExampleSpec extends Specification with ScalaCheck with CheckAll {
+  "Example" should {
+    "satisfy relevant laws" in {
+      checkAll(equal.laws[Example[Int]])
+      checkAll(traverse.laws[Example])
+    }
+  }
+}

--- a/core/src/test/scala/matryoshka/exp/Exp.scala
+++ b/core/src/test/scala/matryoshka/exp/Exp.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.exp
+
+import matryoshka._
+
+import java.lang.String
+import scala.{Int, Symbol}
+
+import org.scalacheck._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+
+sealed trait Exp[A]
+case class Num[A](value: Int) extends Exp[A]
+case class Mul[A](left: A, right: A) extends Exp[A]
+case class Var[A](value: Symbol) extends Exp[A]
+case class Lambda[A](param: Symbol, body: A) extends Exp[A]
+case class Apply[A](func: A, arg: A) extends Exp[A]
+case class Let[A](name: Symbol, value: A, inBody: A) extends Exp[A]
+
+object Exp {
+  implicit val arbSymbol = Arbitrary(Arbitrary.arbitrary[String].map(Symbol(_)))
+
+  implicit val arbitrary: Arbitrary ~> λ[α => Arbitrary[Exp[α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Exp[α]]]) {
+      def apply[α](arb: Arbitrary[α]): Arbitrary[Exp[α]] =
+        Arbitrary(Gen.oneOf(
+          Arbitrary.arbitrary[Int].map(Num[α](_)),
+          (arb.arbitrary ⊛ arb.arbitrary)(Mul(_, _)),
+          Arbitrary.arbitrary[Symbol].map(Var[α](_)),
+          (Arbitrary.arbitrary[Symbol] ⊛ arb.arbitrary)(Lambda(_, _)),
+          (arb.arbitrary ⊛ arb.arbitrary)(Apply(_, _)),
+          (Arbitrary.arbitrary[Symbol] ⊛ arb.arbitrary ⊛ arb.arbitrary)(
+            Let(_, _, _))))
+    }
+
+  implicit val traverse: Traverse[Exp] = new Traverse[Exp] {
+    def traverseImpl[G[_], A, B](fa: Exp[A])(f: A => G[B])(implicit G: Applicative[G]): G[Exp[B]] = fa match {
+      case Num(v)           => G.point(Num(v))
+      case Mul(left, right) => G.apply2(f(left), f(right))(Mul(_, _))
+      case Var(v)           => G.point(Var(v))
+      case Lambda(p, b)     => G.map(f(b))(Lambda(p, _))
+      case Apply(func, arg) => G.apply2(f(func), f(arg))(Apply(_, _))
+      case Let(n, v, i)     => G.apply2(f(v), f(i))(Let(n, _, _))
+    }
+  }
+
+  // NB: an unusual definition of equality, in that only the first 3 characters
+  //     of variable names are significant. This is to distinguish it from `==`
+  //     as well as from a derivable Equal.
+  implicit val equal: Equal ~> λ[α => Equal[Exp[α]]] =
+    new (Equal ~> λ[α => Equal[Exp[α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal[Exp[α]] {
+          case (Num(v1), Num(v2))                 => v1 ≟ v2
+          case (Mul(a1, b1), Mul(a2, b2))         =>
+            eq.equal(a1, a2) && eq.equal(b1, b2)
+          case (Var(s1), Var(s2))                 =>
+            s1.name.substring(0, 3 min s1.name.length) ==
+              s2.name.substring(0, 3 min s2.name.length)
+          case (Lambda(p1, a1), Lambda(p2, a2))   =>
+            p1 == p2 && eq.equal(a1, a2)
+          case (Apply(f1, a1), Apply(f2, a2))     =>
+            eq.equal(f1, f2) && eq.equal(a1, a2)
+          case (Let(n1, v1, i1), Let(n2, v2, i2)) =>
+            n1 == n2 && eq.equal(v1, v2) && eq.equal(i1, i2)
+          case _                                  => false
+        }
+    }
+
+  // NB: Something like this currently needs to be defined for any Functor in
+  //     order to get the generalize operations for the algebra.
+  implicit def toExpAlgebraOps[A](a: Algebra[Exp, A]): AlgebraOps[Exp, A] =
+    toAlgebraOps[Exp, A](a)
+
+  implicit val show: Show ~> λ[α => Show[Exp[α]]] =
+    new (Show ~> λ[α => Show[Exp[α]]]) {
+      def apply[α](show: Show[α]) =
+        Show.show {
+          case Num(v)       => v.shows
+          case Mul(a, b)    =>
+            "Mul(" + show.shows(a) + ", " + show.shows(b) + ")"
+          case Var(s)       => "$" + s.name
+          case Lambda(p, a) => "Lambda(" + p.name + ", " + show.shows(a) + ")"
+          case Apply(f, a)  =>
+            "Apply(" + show.shows(f) + ", " + show.shows(a) + ")"
+          case Let(n, v, i) =>
+            "Let(" + n.name + ", " + show.shows(v) + ", " + show.shows(i) + ")"
+        }
+    }
+
+  implicit val unzip = new Unzip[Exp] {
+    def unzip[A, B](f: Exp[(A, B)]) = (f.map(_._1), f.map(_._2))
+  }
+}

--- a/core/src/test/scala/matryoshka/exp/package.scala
+++ b/core/src/test/scala/matryoshka/exp/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scala.{Int, Symbol}
+
+package object exp {
+  def num(v: Int) = Fix[Exp](Num(v))
+  def mul(left: Fix[Exp], right: Fix[Exp]) = Fix[Exp](Mul(left, right))
+  def vari(v: Symbol) = Fix[Exp](Var(v))
+  def lam(param: Symbol, body: Fix[Exp]) = Fix[Exp](Lambda(param, body))
+  def ap(func: Fix[Exp], arg: Fix[Exp]) = Fix[Exp](Apply(func, arg))
+  def let(name: Symbol, v: Fix[Exp], inBody: Fix[Exp]) = Fix[Exp](Let(name, v, inBody))
+}

--- a/core/src/test/scala/matryoshka/exp2/Exp2.scala
+++ b/core/src/test/scala/matryoshka/exp2/Exp2.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.exp2
+
+import matryoshka._
+
+import scala.Int
+
+import org.scalacheck._
+import scalaz.{Apply => _, _}, Scalaz._
+
+sealed trait Exp2[A]
+case class Const[A]() extends Exp2[A]
+case class Num2[A](value: Int) extends Exp2[A]
+case class Single[A](a: A) extends Exp2[A]
+
+object Exp2 {
+  implicit val arbitrary: Arbitrary ~> λ[α => Arbitrary[Exp2[α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Exp2[α]]]) {
+      def apply[α](arb: Arbitrary[α]): Arbitrary[Exp2[α]] =
+        Arbitrary(Gen.oneOf(
+          Gen.const(Const[α]),
+          Arbitrary.arbitrary[Int].map(Num2[α](_)),
+          arb.arbitrary.map(Single(_))))
+    }
+
+  implicit val functor: Functor[Exp2] = new Functor[Exp2] {
+    def map[A, B](fa: Exp2[A])(f: A => B): Exp2[B] = fa match {
+      case Const()   => Const[B]()
+      case Num2(v)   => Num2[B](v)
+      case Single(a) => Single(f(a))
+    }
+  }
+
+  implicit val show: Show ~> λ[α => Show[Exp2[α]]] =
+    new (Show ~> λ[α => Show[Exp2[α]]]) {
+      def apply[α](show: Show[α]) =
+        Show.show {
+          case Const()   => "Const()"
+          case Num2(v)   => "Num2(" + v.shows + ")"
+          case Single(a) => "Single(" + show.shows(a) + ")"
+        }
+    }
+
+  implicit val equal: Equal ~> λ[α => Equal[Exp2[α]]] =
+    new (Equal ~> λ[α => Equal[Exp2[α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal[Exp2[α]] {
+          case (Const(), Const())       => true
+          case (Num2(v1), Num2(v2))     => v1 ≟ v2
+          case (Single(a1), Single(a2)) => eq.equal(a1, a2)
+          case _                        => false
+        }
+    }
+}

--- a/core/src/test/scala/matryoshka/exp2/package.scala
+++ b/core/src/test/scala/matryoshka/exp2/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scala.Int
+
+package object exp2 {
+  def const = Fix[Exp2](Const())
+  def num2(v: Int) = Fix[Exp2](Num2(v))
+  def single(a: Fix[Exp2]) = Fix[Exp2](Single(a))
+}

--- a/core/src/test/scala/matryoshka/helpers/package.scala
+++ b/core/src/test/scala/matryoshka/helpers/package.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scala.Predef.implicitly
+
+import org.scalacheck._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+
+package object helpers {
+  implicit def NTArbitrary[F[_], A](
+    implicit A: Arbitrary[A], F: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary[F[A]] =
+    F(A)
+
+  implicit def corecArbitrary[T[_[_]]: Corecursive, F[_]: Functor](
+    implicit F: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary[T[F]] =
+    Arbitrary(Gen.sized(size =>
+      F(
+        if (size <= 0)
+          Arbitrary(Gen.fail[T[F]])
+        else
+          Arbitrary(Gen.resize(size - 1, corecArbitrary[T, F].arbitrary))).arbitrary.map(_.embed)))
+
+  implicit def freeArbitrary[F[_]](
+    implicit F: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary ~> λ[α => Arbitrary[Free[F, α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Free[F, α]]]) {
+      def apply[α](arb: Arbitrary[α]) =
+        // FIXME: This is only generating leaf nodes
+        Arbitrary(Gen.sized(size =>
+          if (size <= 1)
+            arb.map(_.point[Free[F, ?]]).arbitrary
+          else
+            Gen.oneOf(
+              arb.arbitrary.map(_.point[Free[F, ?]]),
+              F(freeArbitrary[F](F)(arb)).arbitrary.map(Free.roll))))
+    }
+
+  implicit def freeEqual[F[_]: Functor](
+    implicit F: Equal ~> λ[α => Equal[F[α]]]):
+      Equal ~> λ[α => Equal[Free[F, α]]] =
+    new (Equal ~> λ[α => Equal[Free[F, α]]]) {
+      def apply[α](eq: Equal[α]) =
+        Equal.equal((a, b) => (a.resume, b.resume) match {
+          case (-\/(f1), -\/(f2)) =>
+            F(freeEqual[F](implicitly, F)(eq)).equal(f1, f2)
+          case (\/-(a1), \/-(a2)) => eq.equal(a1, a2)
+          case (_,       _)       => false
+        })
+    }
+}

--- a/core/src/test/scala/matryoshka/instances/fixedpoint/list.scala
+++ b/core/src/test/scala/matryoshka/instances/fixedpoint/list.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.instances.fixedpoint
+
+import matryoshka._, Recursive.ops._
+import matryoshka.patterns._
+
+import scala.Int
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+
+class ListSpec extends Specification with ScalaCheck with specs2.scalaz.Matchers {
+  "apply" should {
+    "be equivalent to scala.List.apply" in {
+      List(1, 2, 3, 4).cata(ListF.listIso.get) must
+        equal(scala.List(1, 2, 3, 4))
+    }
+  }
+
+  "fill" should {
+    "be equivalent to scala.List.fill" ! prop { (v: Int) =>
+      List.fill(100)(v).cata(ListF.listIso.get) must
+        equal(scala.List.fill(100)(v))
+    }
+  }
+
+  "length" should {
+    "count the number of elements" ! prop { (v: Int) =>
+      List.fill(30)(v).length must equal(30)
+    }
+  }
+
+  "headOption" should {
+    "return the first element" in {
+      List(1, 2, 3, 4).headOption must beSome(1)
+    }
+
+    "if there is one" in {
+      List().headOption must beNone
+    }
+  }
+
+  "tailOption" should {
+    "return the remainder of the list" in {
+      List(1, 2, 3, 4).tailOption must equal(List(2, 3, 4).some)
+      List(1).tailOption must equal(List[Int]().some)
+    }
+
+    "if there is one" in {
+      List().tailOption must beNone
+    }
+  }
+}

--- a/core/src/test/scala/matryoshka/instances/fixedpoint/partial.scala
+++ b/core/src/test/scala/matryoshka/instances/fixedpoint/partial.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.instances.fixedpoint
+
+import matryoshka._
+import matryoshka.helpers._
+import matryoshka.specs2.scalacheck.CheckAll
+
+import scala.Predef.implicitly
+import scala.Int
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+class PartialSpec extends Specification with ScalaCheck with CheckAll {
+  implicit def eitherArbitrary[A: Arbitrary]:
+      Arbitrary ~> λ[β => Arbitrary[A \/ β]] =
+    new (Arbitrary ~> λ[β => Arbitrary[A \/ β]]) {
+      def apply[β](arb: Arbitrary [β]) =
+        Arbitrary(Gen.oneOf(
+          Arbitrary.arbitrary[A].map(-\/(_)),
+          arb.arbitrary.map(\/-(_))))
+    }
+
+  /** For testing cases that should work with truly diverging functions. */
+  def sometimesNeverGen[A: Arbitrary]: Gen[Partial[A]] =
+    Gen.oneOf(Arbitrary.arbitrary[Partial[A]], Gen.const(Partial.never[A]))
+
+  "Partial" should {
+    "satisfy relevant laws" in {
+      checkAll(equal.laws[Partial[Int]](Partial.equal, implicitly))
+      checkAll(monad.laws[Partial](Partial.monad, implicitly, implicitly, implicitly, Partial.equal))
+    }
+  }
+}

--- a/core/src/test/scala/matryoshka/instances/fixedpoint/stream.scala
+++ b/core/src/test/scala/matryoshka/instances/fixedpoint/stream.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.instances.fixedpoint
+
+import matryoshka._
+
+import scala.Int
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+
+class StreamSpec extends Specification with ScalaCheck with specs2.scalaz.Matchers {
+  /** Infinite sequence of Fibonacci numbers (at least until they overflow
+    * int32)
+    */
+  val fib = (1, 0).ana[Nu, (Int, ?)](binarySequence(_ + _))
+
+  /** Generates an infinite stream of the carrier value.
+    */
+  def constantly[A]: Coalgebra[(A, ?), A] = i => (i, i)
+
+  "fib" should {
+    "begin with 1" in {
+      fib.head must equal(1)
+    }
+
+    "lazily generate the correct sequence" in {
+      fib.drop(5).head must equal(8)
+    }
+
+    "have a proper prefix" in {
+      fib.take(5) must equal(List(1, 1, 2, 3, 5))
+    }
+
+    "get a subsequence" in {
+      fib.drop(10).take(5) must equal(List(89, 144, 233, 377, 610))
+    }
+  }
+
+  "constantly" should {
+    "begin with the given value" ! prop { (i: Int) =>
+      i.ana[Nu, (Int, ?)](constantly).head must_== i
+    }
+
+    // FIXME: These two blow up the stack with much larger inputs
+
+    "have the given value at an arbitrary point" ! prop { (i: Int, d: Int) =>
+      i.ana[Nu, (Int, ?)](constantly).drop(20000).head must equal(i)
+    }
+
+    "have subsequence of the given value" ! prop { (i: Int, t: Int) =>
+      i.ana[Nu, (Int, ?)](constantly).take(900) must
+        equal(List.fill(900)(i))
+    }
+  }
+}

--- a/core/src/test/scala/matryoshka/patterns/coenv.scala
+++ b/core/src/test/scala/matryoshka/patterns/coenv.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka.exp._
+import matryoshka.helpers._
+
+import scala.Int
+
+import monocle.law.discipline.IsoTests
+import org.scalacheck._
+import org.specs2.mutable._
+import org.typelevel.discipline.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+
+class CoEnvSpec extends Specification with Discipline {
+  implicit def NTArbitrary[F[_], A](implicit A: Arbitrary[A], F: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary[F[A]] =
+    F(A)
+
+  implicit def coEnvArbitrary[E: Arbitrary, F[_]](
+    implicit F: Arbitrary ~> λ[α => Arbitrary[F[α]]]):
+      Arbitrary ~> λ[α => Arbitrary[CoEnv[E, F, α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[CoEnv[E, F, α]]]) {
+      def apply[α](arb: Arbitrary[α]) =
+        // NB: Not sure why this version doesn’t work.
+        // Arbitrary.arbitrary[E \/ F[α]] ∘ (CoEnv(_))
+        Arbitrary(Gen.oneOf(
+          Arbitrary.arbitrary[E].map(_.left),
+          F(arb).arbitrary.map(_.right))) ∘ (CoEnv(_))
+    }
+
+  checkAll("CoEnv ⇔ Free", IsoTests(CoEnv.freeIso[Int, Exp]))
+}

--- a/core/src/test/scala/matryoshka/patterns/diff.scala
+++ b/core/src/test/scala/matryoshka/patterns/diff.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._, Recursive.ops._
+import matryoshka.example._
+import matryoshka.exp._
+import matryoshka.helpers._
+import matryoshka.specs2.scalacheck.CheckAll
+
+import scala.Predef.{implicitly, wrapString}
+import scala.{Int, List, Unit}
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalaCheckBinding._
+import scalaz.scalacheck.ScalazProperties._
+
+trait DiffArb {
+  implicit def diffArbitrary[T[_[_]], F[_]](
+    implicit F: Arbitrary ~> λ[α => Arbitrary[F[α]]], T: Arbitrary[T[F]]):
+      Arbitrary ~> λ[α => Arbitrary[Diff[T, F, α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[Diff[T, F, α]]]) {
+      def apply[α](arb: Arbitrary[α]) =
+        Arbitrary(Gen.oneOf(
+          T.arbitrary.map(Same[T, F, α](_)),
+          F(arb).arbitrary.map(Similar[T, F, α](_)),
+          (T.arbitrary ⊛ T.arbitrary)(Different[T, F, α](_, _)),
+          (F(arb).arbitrary ⊛ F[Unit](implicitly).arbitrary)(
+            LocallyDifferent[T, F, α](_, _)),
+          F(arb).arbitrary.map(Inserted[T, F, α](_)),
+          F(arb).arbitrary.map(Deleted[T, F, α](_)),
+          T.arbitrary.map(Added[T, F, α](_)),
+          T.arbitrary.map(Removed[T, F, α](_))))
+    }
+}
+
+// NB: This is a separate spec because scalaz.Matchers.equal conflicts with
+//     ScalazProperties.equal. There is probably a better way to disambiguate
+//     them.
+class DiffLaws extends Specification with DiffArb with ScalaCheck with CheckAll {
+  "Diff" should {
+    "satisfy relevant laws" in {
+      checkAll(equal.laws[Diff[Mu, Exp, Int]])
+      checkAll(traverse.laws[Diff[Mu, Exp, ?]])
+    }
+  }
+}
+
+class DiffSpec extends Specification with DiffArb with specs2.scalaz.Matchers {
+  "diff" should {
+    "find non-recursive differences" in {
+      NonRec[Mu[Example]]("a", 1).embed.paraMerga(NonRec[Mu[Example]]("b", 1).embed)(diff) must
+      equal(CorecursiveOps[Mu, Diff[Mu, Example, ?]](
+        LocallyDifferent(NonRec[DiffT[Mu, Example]]("a", 1),
+                         NonRec[Unit]("b", 1))).embed)
+    }
+
+    "create `Removed` for shorter list" in {
+      OneList(List(Empty[Mu[Example]]().embed, Empty[Mu[Example]]().embed)).embed.paraMerga(
+        OneList(List(NonRec[Mu[Example]]("x", 3).embed)).embed)(diff) must
+        equal(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Similar(OneList(List(
+          CorecursiveOps[Mu, Diff[Mu, Example, ?]](Different(Empty[Mu[Example]]().embed, NonRec[Mu[Example]]("x", 3).embed)).embed,
+          CorecursiveOps[Mu, Diff[Mu, Example, ?]](Removed(Empty[Mu[Example]]().embed)).embed)))).embed)
+    }
+
+    "create `Added` for longer list" in {
+      OneList(List(NonRec[Mu[Example]]("x", 3).embed)).embed.paraMerga(
+        OneList(List(Empty[Mu[Example]]().embed, Empty[Mu[Example]]().embed)).embed)(diff) must
+        equal(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Similar(OneList(List(
+          CorecursiveOps[Mu, Diff[Mu, Example, ?]](Different(NonRec[Mu[Example]]("x", 3).embed, Empty[Mu[Example]]().embed)).embed,
+          CorecursiveOps[Mu, Diff[Mu, Example, ?]](Added(Empty[Mu[Example]]().embed)).embed)))).embed)
+    }
+
+    "choose “simplest” diff" in {
+      OneList(List(Empty[Mu[Example]]().embed)).embed.paraMerga(
+        OneList(List(NonRec[Mu[Example]]("x", 3).embed, Empty[Mu[Example]]().embed)).embed)(diff) must
+        equal(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Similar(OneList(List(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Added(NonRec[Mu[Example]]("x", 3).embed)).embed, CorecursiveOps[Mu, Diff[Mu, Example, ?]](Same(Empty[Mu[Example]]().embed)).embed)))).embed)
+    }.pendingUntilFixed("can’t just walk lists from start to finish")
+
+    "create `Removed` and `Added` for mixed lists" in {
+      TwoLists(List(Empty[Mu[Example]]().embed, Empty[Mu[Example]]().embed), List(Empty[Mu[Example]]().embed)).embed.paraMerga(
+        TwoLists(
+          List(NonRec[Mu[Example]]("x", 3).embed),
+          List(Empty[Mu[Example]]().embed, Empty[Mu[Example]]().embed, Empty[Mu[Example]]().embed)).embed)(diff) must
+        equal(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Similar(TwoLists(
+          List(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Different(Empty[Mu[Example]]().embed, NonRec[Mu[Example]]("x", 3).embed)).embed, CorecursiveOps[Mu, Diff[Mu, Example, ?]](Removed(Empty[Mu[Example]]().embed)).embed),
+          List(CorecursiveOps[Mu, Diff[Mu, Example, ?]](Same(Empty[Mu[Example]]().embed)).embed, CorecursiveOps[Mu, Diff[Mu, Example, ?]](Added(Empty[Mu[Example]]().embed)).embed, CorecursiveOps[Mu, Diff[Mu, Example, ?]](Added(Empty[Mu[Example]]().embed)).embed)))).embed)
+    }
+  }
+
+  "shows" should {
+    // NB: The `Different` case should look like this, but `drawTree` doesn’t
+    //     properly handle `Show`s with newlines.
+    //
+    //     +- vvvvvvvvv left  vvvvvvvvv
+    //     |  Empty()
+    //     |  =========================
+    //     |  NonRec("x", 3)
+    //     |  ^^^^^^^^^ right ^^^^^^^^^
+    //     |
+    "print a tree diff" in {
+      val left =
+        TwoLists(
+          List(
+            NonRec[Mu[Example]]("foo", 3).embed,
+            SemiRec(2,
+              SemiRec(8,
+                NonRec[Mu[Example]]("meh", 6).embed).embed).embed,
+            Empty[Mu[Example]]().embed,
+            Empty[Mu[Example]]().embed),
+          List(Empty[Mu[Example]]().embed)).embed
+
+      val right =
+        TwoLists(
+          List(
+            NonRec[Mu[Example]]("bar", 3).embed,
+            SemiRec(10,
+              SemiRec(8,
+                NonRec[Mu[Example]]("meh", 7).embed).embed).embed,
+            NonRec[Mu[Example]]("x", 3).embed),
+          List(
+            Empty[Mu[Example]]().embed,
+            Empty[Mu[Example]]().embed,
+            Empty[Mu[Example]]().embed)).embed
+
+      Recursive[Mu].cata((left paraMerga right)(diff))(toTree).drawTree must
+        equal("""TwoLists([(),(),(),()], [(),(),()])
+                ||
+                |+- NonRec("foo", 3) <=/=> NonRec("bar", 3)
+                ||
+                |+- SemiRec(2, ()) <=/=> SemiRec(10, ())
+                ||  |
+                ||  `- SemiRec(8, ())
+                ||     |
+                ||     `- NonRec("meh", 6) <=/=> NonRec("meh", 7)
+                ||
+                |+- vvvvvvvvv left  vvvvvvvvv
+                |Empty()
+                |=========================
+                |NonRec("x", 3)
+                |^^^^^^^^^ right ^^^^^^^^^
+                ||
+                |+- <--- Empty()
+                ||
+                |+- ...
+                ||
+                |+- +++> Empty()
+                ||
+                |`- +++> Empty()
+                |""".stripMargin)
+    }
+  }
+}

--- a/core/src/test/scala/matryoshka/patterns/listF.scala
+++ b/core/src/test/scala/matryoshka/patterns/listF.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka.helpers._
+import matryoshka.specs2.scalacheck.CheckAll
+
+import java.lang.String
+import scala.Int
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+class ListFSpec extends Specification with ScalaCheck with CheckAll {
+  implicit def listFArbitrary[A: Arbitrary]:
+      Arbitrary ~> λ[β => Arbitrary[ListF[A, β]]] =
+    new (Arbitrary ~> λ[β => Arbitrary[ListF[A, β]]]) {
+      def apply[β](arb: Arbitrary[β]) =
+        Arbitrary(Gen.oneOf(
+          NilF[A, β]().point[Gen],
+          (Arbitrary.arbitrary[A] ⊛ arb.arbitrary)(ConsF[A, β])))
+    }
+
+  "ListF should satisfy relevant laws" >> {
+    checkAll(equal.laws[ListF[String, Int]])
+    checkAll(bitraverse.laws[ListF])
+  }
+}

--- a/core/src/test/scala/matryoshka/patterns/potentialFailure.scala
+++ b/core/src/test/scala/matryoshka/patterns/potentialFailure.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka.patterns
+
+import matryoshka._
+import matryoshka.exp._
+import matryoshka.helpers._
+import matryoshka.specs2.scalacheck.CheckAll
+
+import java.lang.String
+import scala.Int
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+class PotentialFailureSpec extends Specification with ScalaCheck with CheckAll {
+  implicit def potentialFailureArbitrary[T[_[_]], F[_], E: Arbitrary](
+    implicit F: Arbitrary ~> λ[α => Arbitrary[F[α]]], T: Arbitrary[T[F]]):
+      Arbitrary ~> λ[α => Arbitrary[PotentialFailure[T, F, E, α]]] =
+    new (Arbitrary ~> λ[α => Arbitrary[PotentialFailure[T, F, E, α]]]) {
+      def apply[α](arb: Arbitrary[α]) =
+        Arbitrary(Gen.oneOf(
+          T.arbitrary.map(Success[T, F, E, α](_)),
+          Arbitrary.arbitrary[E].map(Failure[T, F, E, α](_)),
+          F(arb).arbitrary.map(PartialFailure[T, F, E, α](_))))
+    }
+
+  "PotentialFailure should satisfy relevant laws" >> {
+    checkAll(equal.laws[PotentialFailure[Fix, Exp, String, Int]])
+    checkAll(bitraverse.laws[PotentialFailure[Fix, Exp, ?, ?]])
+  }
+}


### PR DESCRIPTION
- Add type aliases for various types (like `Free` and `Cofree`) to show
  the equivalences, and start moving toward fixed-point alternatives.
- Add `AlgebraIso` to make isomorphic algebras explicit.
- A few new pattern functors (in their own package) – `CoEnv`, `ListF`,
  `Diff`, and `PotentialFailue`.
- Add some tests for the Stream alias (mostly just to have a place to put some coalgebras I had written).