### PR TITLE
Use "algebra" types in all signatures

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- use "algebra" and "transform" type aliases in all signatures

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This diagram covers the major classes of transformations. The most basic ones ar
 Here is a very simple example of an algebra (`eval`) and how to apply it to a recursive structure.
 
 ```scala
-val eval: Expr[Long] => Long = {
+val eval: Algebra[Expr, Long] = { // i.e. Expr[Long] => Long
   case Num(x)    => x
   case Mul(x, y) => x * y
 }

--- a/core/shared/src/main/scala/matryoshka/CoalgebraOps.scala
+++ b/core/shared/src/main/scala/matryoshka/CoalgebraOps.scala
@@ -20,8 +20,8 @@ import scalaz._
 import scalaz.syntax.monad._
 
 sealed class CoalgebraOps[F[_], A](self: Coalgebra[F, A]) {
-  def generalize[M[_]: Monad](implicit F: Functor[F]): GCoalgebra[M, F, A] =
-    self(_).map(_.map(_.point[M]))
+  def generalize[N[_]: Monad](implicit F: Functor[F]): GCoalgebra[N, F, A] =
+    self(_).map(_.point[N])
 
   def generalizeM[M[_]: Monad]: CoalgebraM[M, F, A] = self(_).point[M]
 

--- a/core/shared/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Corecursive.scala
@@ -27,36 +27,36 @@ import simulacrum.typeclass
 @typeclass trait Corecursive[T[_[_]]] {
   def embed[F[_]: Functor](t: F[T[F]]): T[F]
 
-  def ana[F[_]: Functor, A](a: A)(f: A => F[A]): T[F] =
-    embed(f(a) ∘ (ana(_)(f)))
+  def ana[F[_]: Functor, A](a: A)(f: Coalgebra[F, A]): T[F] =
+    embed((f(a): F[A]) ∘ (ana(_)(f)))
 
-  def anaM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[A]]): M[T[F]] =
+  def anaM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: CoalgebraM[M, F, A]): M[T[F]] =
     f(a).flatMap(_.traverse(anaM(_)(f))) ∘ (embed(_))
 
-  def gana[M[_], F[_]: Functor, A](
+  def gana[N[_], F[_]: Functor, A](
     a: A)(
-    k: DistributiveLaw[M, F], f: A => F[M[A]])(
-    implicit M: Monad[M]):
+    k: DistributiveLaw[N, F], f: GCoalgebra[N, F, A])(
+    implicit N: Monad[N]):
       T[F] = {
-    def loop(x: M[F[M[A]]]): T[F] = embed(k(x) ∘ (x => loop(M.lift(f)(x.join))))
+    def loop(x: N[F[N[A]]]): T[F] = embed(k(x) ∘ (x => loop(N.lift(f)(x.join))))
 
-    loop(f(a).point[M])
+    loop(f(a).point[N])
   }
 
-  def ganaM[M[_]: Traverse, N[_]: Monad, F[_]: Traverse, A](
+  def ganaM[N[_]: Traverse, M[_]: Monad, F[_]: Traverse, A](
     a: A)(
-    k: DistributiveLaw[M, F], f: A => N[F[M[A]]])(
-    implicit M: Monad[M]):
-      N[T[F]] = {
-    def loop(x: M[F[M[A]]]): N[T[F]] =
-      k(x).traverse(x => M.lift(f)(x.join).sequence >>= loop) ∘ (embed(_))
+    k: DistributiveLaw[N, F], f: GCoalgebraM[N, M, F, A])(
+    implicit N: Monad[N]):
+      M[T[F]] = {
+    def loop(x: N[F[N[A]]]): M[T[F]] =
+      k(x).traverse(x => N.lift(f)(x.join).sequence >>= loop) ∘ (embed(_))
 
-    f(a) ∘ (_.point[M]) >>= loop
+    f(a) ∘ (_.point[N]) >>= loop
   }
 
   def elgotAna[M[_], F[_]: Functor, A](
     a: A)(
-    k: DistributiveLaw[M, F], ψ: A => M[F[A]])(
+    k: DistributiveLaw[M, F], ψ: CoalgebraM[M, F, A])(
     implicit M: Monad[M]):
       T[F] = {
     def loop(x: M[F[A]]): T[F] = embed(k(x) ∘ (x => loop(M.lift(ψ)(x).join)))
@@ -66,49 +66,49 @@ import simulacrum.typeclass
 
   /** An unfold that can short-circuit certain sections.
     */
-  def apo[F[_]: Functor, A](a: A)(f: A => F[T[F] \/ A]): T[F] =
+  def apo[F[_]: Functor, A](a: A)(f: GCoalgebra[T[F] \/ ?, F, A]): T[F] =
     // NB: This is not implemented with [[matryoshka.distApo]] because that
     //     would add a [[matryoshka.Recursive]] constraint.
     embed(f(a) ∘ (_.fold(Predef.identity, apo(_)(f))))
 
-  def elgotApo[F[_]: Functor, A](a: A)(f: A => T[F] \/ F[A]): T[F] =
+  def elgotApo[F[_]: Functor, A](a: A)(f: CoalgebraM[T[F] \/ ?, F, A]): T[F] =
     // NB: This is not implemented with [[matryoshka.distApo]] because that
     //     would add a [[matryoshka.Recursive]] constraint.
     f(a).fold(Predef.identity, fa => embed(fa ∘ (elgotApo(_)(f))))
 
   /** An unfold that can handle sections with a secondary unfold.
     */
-  def gapo[F[_]: Functor, A, B](a: A)(ψ0: B => F[B], ψ: A => F[B \/ A]): T[F] =
+  def gapo[F[_]: Functor, A, B](a: A)(ψ0: Coalgebra[F, B], ψ: GCoalgebra[B \/ ?, F, A]): T[F] =
     embed(ψ(a) ∘ (_.fold(ana(_)(ψ0), gapo(_)(ψ0, ψ))))
 
-  def apoM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: A => M[F[T[F] \/ A]]): M[T[F]] =
+  def apoM[F[_]: Traverse, M[_]: Monad, A](a: A)(f: GCoalgebraM[T[F] \/ ?, M, F, A]): M[T[F]] =
     f(a).flatMap(_.traverse(_.fold(_.point[M], apoM(_)(f)))) ∘ (embed(_))
 
   def postpro[F[_]: Functor, A](
     a: A)(
-    e: F ~> F, g: A => F[A])(
+    e: F ~> F, g: Coalgebra[F, A])(
     implicit T: Recursive[T]):
       T[F] =
     gpostpro[Id, F, A](a)(distAna, e, g)
 
-  def gpostpro[M[_], F[_]: Functor, A](
+  def gpostpro[N[_], F[_]: Functor, A](
     a: A)(
-    k: DistributiveLaw[M, F], e: F ~> F, ψ: A => F[M[A]])(
-    implicit T: Recursive[T], M: Monad[M]):
+    k: DistributiveLaw[N, F], e: F ~> F, ψ: GCoalgebra[N, F, A])(
+    implicit T: Recursive[T], N: Monad[N]):
       T[F] = {
-    def loop(ma: M[A]): T[F] =
-      embed(k(M.lift(ψ)(ma)) ∘ (x => ana(loop(x.join))(x => e(x.project))))
+    def loop(ma: N[A]): T[F] =
+      embed(k(N.lift(ψ)(ma)) ∘ (x => ana(loop(x.join))(x => e(x.project))))
 
-    loop(a.point[M])
+    loop(a.point[N])
   }
 
-  def futu[F[_]: Functor, A](a: A)(f: A => F[Free[F, A]]): T[F] =
+  def futu[F[_]: Functor, A](a: A)(f: GCoalgebra[Free[F, ?], F, A]): T[F] =
     gana[Free[F, ?], F, A](a)(distFutu, f)
 
-  def elgotFutu[F[_]: Functor, A](a: A)(f: A => Free[F, F[A]]): T[F] =
+  def elgotFutu[F[_]: Functor, A](a: A)(f: CoalgebraM[Free[F, ?], F, A]): T[F] =
     elgotAna[Free[F, ?], F, A](a)(distFutu, f)
 
-  def futuM[M[_]: Monad, F[_]: Traverse, A](a: A)(f: A => M[F[Free[F, A]]]):
+  def futuM[M[_]: Monad, F[_]: Traverse, A](a: A)(f: GCoalgebraM[Free[F, ?], M, F, A]):
       M[T[F]] = {
     def loop(free: Free[F, A]): M[T[F]] =
       free.fold(futuM(_)(f), _.traverse(loop) ∘ (embed[F]))

--- a/core/shared/src/main/scala/matryoshka/FreeOps.scala
+++ b/core/shared/src/main/scala/matryoshka/FreeOps.scala
@@ -19,6 +19,6 @@ package matryoshka
 import scalaz._
 
 sealed class FreeOps[F[_], A](self: Free[F, A]) {
-  def interpretCata(φ: F[A] => A)(implicit F: Functor[F]): A =
+  def interpretCata(φ: Algebra[F, A])(implicit F: Functor[F]): A =
     matryoshka.interpretCata(self)(φ)
 }

--- a/core/shared/src/main/scala/matryoshka/FunctorT.scala
+++ b/core/shared/src/main/scala/matryoshka/FunctorT.scala
@@ -60,23 +60,23 @@ import simulacrum.{typeclass}
   def transApoT[F[_]: Functor](t: T[F])(f: T[F] => T[F] \/ T[F]): T[F] =
     f(t).fold(Predef.identity, map(_)(_.map(transApoT(_)(f))))
 
-  def transCata[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[G]] => G[T[G]]): T[G] =
+  def transCata[F[_]: Functor, G[_]: Functor](t: T[F])(f: AlgebraicTransform[T, F, G]): T[G] =
     map(t)(ft => f(ft.map(transCata(_)(f))))
 
-  def transAna[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[F]]): T[G] =
+  def transAna[F[_]: Functor, G[_]: Functor](t: T[F])(f: CoalgebraicTransform[T, F, G]): T[G] =
     map(t)(f(_).map(transAna(_)(f)))
 
-  def transPrepro[F[_]: Functor, G[_]: Functor](t: T[F])(e: F ~> F, f: F[T[G]] => G[T[G]]): T[G] =
+  def transPrepro[F[_]: Functor, G[_]: Functor](t: T[F])(e: F ~> F, f: AlgebraicTransform[T, F, G]): T[G] =
     map(t)(ft => f(ft ∘ (x => transPrepro(transCata[F, F](x)(e(_)))(e, f))))
 
-  def transPostpro[F[_]: Functor, G[_]: Functor](t: T[F])(e: G ~> G, f: F[T[F]] => G[T[F]]): T[G] =
+  def transPostpro[F[_]: Functor, G[_]: Functor](t: T[F])(e: G ~> G, f: CoalgebraicTransform[T, F, G]): T[G] =
     map(t)(f(_) ∘ (x => transAna(transPostpro(x)(e, f))(e)))
 
-  def transPara[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[(T[F], T[G])] => G[T[G]]):
+  def transPara[F[_]: Functor, G[_]: Functor](t: T[F])(f: GAlgebraicTransform[T, (T[F], ?), F, G]):
       T[G] =
     map(t)(ft => f(ft.map(tf => (tf, transPara(tf)(f)))))
 
-  def transApo[F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[F]] => G[T[G] \/ T[F]]):
+  def transApo[F[_]: Functor, G[_]: Functor](t: T[F])(f: GCoalgebraicTransform[T, (T[G] \/ ?), F, G]):
       T[G] =
     map(t)(f(_).map(_.fold(Predef.identity, transApo(_)(f))))
 

--- a/core/shared/src/main/scala/matryoshka/IdOps.scala
+++ b/core/shared/src/main/scala/matryoshka/IdOps.scala
@@ -19,98 +19,98 @@ package matryoshka
 import scalaz._
 
 sealed class IdOps[A](self: A) {
-  def hylo[F[_]: Functor, B](f: F[B] => B, g: A => F[A]): B =
+  def hylo[F[_]: Functor, B](f: Algebra[F, B], g: Coalgebra[F, A]): B =
     matryoshka.hylo(self)(f, g)
-  def hyloM[M[_]: Monad, F[_]: Traverse, B](f: F[B] => M[B], g: A => M[F[A]]):
+  def hyloM[M[_]: Monad, F[_]: Traverse, B](f: AlgebraM[M, F, B], g: CoalgebraM[M, F, A]):
       M[B] =
     matryoshka.hyloM(self)(f, g)
-  def ghylo[W[_]: Comonad, M[_]: Monad, F[_]: Functor, B](
+    
+  def ghylo[W[_]: Comonad, N[_]: Monad, F[_]: Functor, B](
     w: DistributiveLaw[F, W],
-    m: DistributiveLaw[M, F],
-    f: F[W[B]] => B,
-    g: A => F[M[A]]):
+    n: DistributiveLaw[N, F],
+    f: GAlgebra[W, F, B],
+    g: GCoalgebra[N, F, A]):
       B =
-    matryoshka.ghylo(self)(w, m, f, g)
-
-  def ghyloM[W[_]: Comonad: Traverse, M[_]: Monad: Traverse, N[_]: Monad, F[_]: Traverse, B](
+    matryoshka.ghylo(self)(w, n, f, g)
+  def ghyloM[W[_]: Comonad: Traverse, N[_]: Monad: Traverse, M[_]: Monad, F[_]: Traverse, B](
     w: DistributiveLaw[F, W],
-    m: DistributiveLaw[M, F],
-    f: F[W[B]] => N[B],
-    g: A => N[F[M[A]]]):
-      N[B] =
-    matryoshka.ghyloM(self)(w, m, f, g)
+    n: DistributiveLaw[N, F],
+    f: GAlgebraM[W, M, F, B],
+    g: GCoalgebraM[N, M, F, A]):
+      M[B] =
+    matryoshka.ghyloM(self)(w, n, f, g)
 
-  def dyna[F[_]: Functor, B](φ: F[Cofree[F, B]] => B, ψ: A => F[A]): B =
+  def dyna[F[_]: Functor, B](φ: GAlgebra[Cofree[F, ?], F, B], ψ: Coalgebra[F, A]): B =
     matryoshka.dyna(self)(φ, ψ)
 
-  def codyna[F[_]: Functor, B](φ: F[B] => B, ψ: A => F[Free[F, A]]): B =
+  def codyna[F[_]: Functor, B](φ: Algebra[F, B], ψ: GCoalgebra[Free[F, ?], F, A]): B =
     matryoshka.codyna(self)(φ, ψ)
 
-  def codynaM[M[_]: Monad, F[_]: Traverse, B](φ: F[B] => M[B], ψ: A => M[F[Free[F, A]]]): M[B] =
+  def codynaM[M[_]: Monad, F[_]: Traverse, B](φ: AlgebraM[M, F, B], ψ: GCoalgebraM[Free[F, ?], M, F, A]): M[B] =
     matryoshka.codynaM(self)(φ, ψ)
 
   def chrono[F[_]: Functor, B](
-    g: F[Cofree[F, B]] => B, f: A => F[Free[F, A]]):
+    g: GAlgebra[Cofree[F, ?], F, B], f: GCoalgebra[Free[F, ?], F, A]):
       B =
     matryoshka.chrono(self)(g, f)
 
-  def attributeAna[F[_]: Functor](ψ: A => F[A]): Cofree[F, A] =
+  def attributeAna[F[_]: Functor](ψ: Coalgebra[F, A]): Cofree[F, A] =
     matryoshka.attributeAna(self)(ψ)
 
-  def attributeAnaM[M[_]: Monad, F[_]: Traverse](ψ: A => M[F[A]]):
+  def attributeAnaM[M[_]: Monad, F[_]: Traverse](ψ: CoalgebraM[M, F, A]):
       M[Cofree[F, A]] =
     matryoshka.attributeAnaM(self)(ψ)
 
-  def freeAna[F[_]: Functor, B](ψ: A => B \/ F[A]): Free[F, B] =
+  def freeAna[F[_]: Functor, B](ψ: CoalgebraM[B \/ ?, F, A]): Free[F, B] =
     matryoshka.freeAna(self)(ψ)
 
-  def elgot[F[_]: Functor, B](φ: F[B] => B, ψ: A => B \/ F[A]): B =
+  def elgot[F[_]: Functor, B](φ: Algebra[F, B], ψ: CoalgebraM[B \/ ?, F, A]): B =
     matryoshka.elgot(self)(φ, ψ)
 
-  def coelgot[F[_]: Functor, B](φ: ((A, F[B])) => B, ψ: A => F[A]): B =
+  def coelgot[F[_]: Functor, B](φ: ElgotAlgebra[(A, ?), F, B], ψ: Coalgebra[F, A]): B =
     matryoshka.coelgot(self)(φ, ψ)
   def coelgotM[M[_]] = new CoelgotMPartiallyApplied[M]
   final class CoelgotMPartiallyApplied[M[_]] {
-    def apply[F[_]: Traverse, B](φ: ((A, F[B])) => M[B], ψ: A => M[F[A]])(implicit M: Monad[M]):
+    def apply[F[_]: Traverse, B](φ: ElgotAlgebraM[(A, ?), M, F, B], ψ: CoalgebraM[M, F, A])(implicit M: Monad[M]):
         M[B] =
       matryoshka.coelgotM[M].apply[F, A, B](self)(φ, ψ)
   }
 
-  def ana[T[_[_]], F[_]: Functor](f: A => F[A])(implicit T: Corecursive[T]): T[F] =
+  def ana[T[_[_]], F[_]: Functor](f: Coalgebra[F, A])(implicit T: Corecursive[T]): T[F] =
     T.ana(self)(f)
-  def anaM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[A]])(implicit T: Corecursive[T]): M[T[F]] =
+  def anaM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: CoalgebraM[M, F, A])(implicit T: Corecursive[T]): M[T[F]] =
     T.anaM(self)(f)
-  def gana[T[_[_]], M[_]: Monad, F[_]: Functor](
-    k: DistributiveLaw[M, F], f: A => F[M[A]])(
+  def gana[T[_[_]], N[_]: Monad, F[_]: Functor](
+    k: DistributiveLaw[N, F], f: GCoalgebra[N, F, A])(
     implicit T: Corecursive[T]):
       T[F] =
     T.gana(self)(k, f)
   def elgotAna[T[_[_]], M[_]: Monad, F[_]: Functor](
-    k: DistributiveLaw[M, F], f: A => M[F[A]])(
+    k: DistributiveLaw[M, F], f: CoalgebraM[M, F, A])(
     implicit T: Corecursive[T]):
       T[F] =
     T.elgotAna(self)(k, f)
-  def ganaM[T[_[_]], M[_]: Monad: Traverse, N[_]: Monad, F[_]: Traverse](
-    k: DistributiveLaw[M, F], f: A => N[F[M[A]]])(
+  def ganaM[T[_[_]], N[_]: Monad: Traverse, M[_]: Monad, F[_]: Traverse](
+    k: DistributiveLaw[N, F], f: GCoalgebraM[N, M, F, A])(
     implicit T: Corecursive[T]):
-      N[T[F]] =
+      M[T[F]] =
     T.ganaM(self)(k, f)
-  def apo[T[_[_]], F[_]: Functor](f: A => F[T[F] \/ A])(implicit T: Corecursive[T]): T[F] =
+  def apo[T[_[_]], F[_]: Functor](f: GCoalgebra[T[F] \/ ?, F, A])(implicit T: Corecursive[T]): T[F] =
     T.apo(self)(f)
-  def elgotApo[T[_[_]], F[_]: Functor](f: A => T[F] \/ F[A])(implicit T: Corecursive[T]): T[F] =
+  def elgotApo[T[_[_]], F[_]: Functor](f: ElgotCoalgebra[T[F] \/ ?, F, A])(implicit T: Corecursive[T]): T[F] =
     T.elgotApo(self)(f)
-  def apoM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[T[F] \/ A]])(implicit T: Corecursive[T]): M[T[F]] =
+  def apoM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: GCoalgebraM[T[F] \/ ?, M, F, A])(implicit T: Corecursive[T]): M[T[F]] =
     T.apoM(self)(f)
-  def postpro[T[_[_]]: Recursive, F[_]: Functor](e: F ~> F, g: A => F[A])(implicit T: Corecursive[T]): T[F] =
+  def postpro[T[_[_]]: Recursive, F[_]: Functor](e: F ~> F, g: Coalgebra[F, A])(implicit T: Corecursive[T]): T[F] =
     T.postpro(self)(e, g)
-  def gpostpro[T[_[_]]: Recursive, M[_]: Monad, F[_]: Functor](
-    k: DistributiveLaw[M, F], e: F ~> F, g: A => F[M[A]])(
+  def gpostpro[T[_[_]]: Recursive, N[_]: Monad, F[_]: Functor](
+    k: DistributiveLaw[N, F], e: F ~> F, g: GCoalgebra[N, F, A])(
     implicit T: Corecursive[T]):
       T[F] =
     T.gpostpro(self)(k, e, g)
-  def futu[T[_[_]], F[_]: Functor](f: A => F[Free[F, A]])(implicit T: Corecursive[T]): T[F] =
+  def futu[T[_[_]], F[_]: Functor](f: GCoalgebra[Free[F, ?], F, A])(implicit T: Corecursive[T]): T[F] =
     T.futu(self)(f)
-  def futuM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: A => M[F[Free[F, A]]])(implicit T: Corecursive[T]):
+  def futuM[T[_[_]], M[_]: Monad, F[_]: Traverse](f: GCoalgebraM[Free[F, ?], M, F, A])(implicit T: Corecursive[T]):
       M[T[F]] =
     T.futuM(self)(f)
 }

--- a/core/shared/src/main/scala/matryoshka/Mu.scala
+++ b/core/shared/src/main/scala/matryoshka/Mu.scala
@@ -23,17 +23,17 @@ import scalaz._, Scalaz._
 /** This is for inductive (finite) recursive structures, models the concept of
   * “data”, aka, the “least fixed point”.
   */
-final case class Mu[F[_]](unMu: λ[A => (F[A] => A)] ~> Id)
+final case class Mu[F[_]](unMu: λ[A => Algebra[F, A]] ~> Id)
 object Mu {
   implicit val recursive: Recursive[Mu] = new Recursive[Mu] {
     def project[F[_]: Functor](t: Mu[F]) = lambek(t)
-    override def cata[F[_]: Functor, A](t: Mu[F])(f: F[A] => A) = t.unMu(f)
+    override def cata[F[_]: Functor, A](t: Mu[F])(f: Algebra[F, A]) = t.unMu(f)
   }
 
   implicit val corecursive: Corecursive[Mu] = new Corecursive[Mu] {
     def embed[F[_]: Functor](t: F[Mu[F]]) =
-      Mu(new (λ[A => (F[A] => A)] ~> Id) {
-        def apply[A](fa: F[A] => A): A = fa(t.map(_.cata(fa)))
+      Mu(new (λ[A => Algebra[F, A]] ~> Id) {
+        def apply[A](fa: Algebra[F, A]): A = fa(t.map(_.cata(fa)))
       })
   }
 

--- a/core/shared/src/main/scala/matryoshka/Nu.scala
+++ b/core/shared/src/main/scala/matryoshka/Nu.scala
@@ -24,10 +24,10 @@ import scalaz._, Scalaz._
 sealed abstract class Nu[F[_]] {
   type A
   val a: A
-  val unNu: A => F[A]
+  val unNu: Coalgebra[F, A]
 }
 object Nu {
-  def apply[F[_], B](f: B => F[B], b: B): Nu[F] =
+  def apply[F[_], B](f: Coalgebra[F, B], b: B): Nu[F] =
     new Nu[F] {
       type A = B
       val a = b
@@ -40,7 +40,7 @@ object Nu {
 
   implicit val corecursive: Corecursive[Nu] = new Corecursive[Nu] {
     def embed[F[_]: Functor](t: F[Nu[F]]) = colambek(t)
-    override def ana[F[_]: Functor, A](a: A)(f: A => F[A]) = Nu(f, a)
+    override def ana[F[_]: Functor, A](a: A)(f: Coalgebra[F, A]) = Nu(f, a)
   }
 
   implicit val equalT: EqualT[Nu] = Recursive.equalT[Nu]

--- a/core/shared/src/main/scala/matryoshka/Recursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Recursive.scala
@@ -29,17 +29,17 @@ import simulacrum.typeclass
 @typeclass trait Recursive[T[_[_]]] {
   def project[F[_]: Functor](t: T[F]): F[T[F]]
 
-  def cata[F[_]: Functor, A](t: T[F])(f: F[A] => A): A =
+  def cata[F[_]: Functor, A](t: T[F])(f: Algebra[F, A]): A =
     f(project(t) ∘ (cata(_)(f)))
 
   /** A Kleisli catamorphism. */
-  def cataM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: F[A] => M[A]): M[A] =
+  def cataM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: AlgebraM[M, F, A]): M[A] =
     project(t).traverse(cataM(_)(f)).flatMap(f)
 
   /** A catamorphism generalized with a comonad in inside the functor. */
   def gcata[W[_]: Comonad, F[_]: Functor, A](
     t: T[F])(
-    k: DistributiveLaw[F, W], g: F[W[A]] => A):
+    k: DistributiveLaw[F, W], g: GAlgebra[W, F, A]):
       A = {
     def loop(t: T[F]): W[F[W[A]]] = k(project(t) ∘ (loop(_).map(g).cojoin))
 
@@ -48,7 +48,7 @@ import simulacrum.typeclass
 
   def gcataM[W[_]: Comonad: Traverse, M[_]: Monad, F[_]: Traverse, A](
     t: T[F])(
-    k: DistributiveLaw[F, W], g: F[W[A]] => M[A]):
+    k: DistributiveLaw[F, W], g: GAlgebraM[W, M, F, A]):
       M[A] = {
     def loop(t: T[F]): M[W[F[W[A]]]] =
       project(t).traverse(loop(_) >>= (_.traverse(g) ∘ (_.cojoin))) ∘ (k(_))
@@ -66,37 +66,37 @@ import simulacrum.typeclass
     g(loop(t))
   }
 
-  def para[F[_]: Functor, A](t: T[F])(f: F[(T[F], A)] => A): A =
+  def para[F[_]: Functor, A](t: T[F])(f: GAlgebra[(T[F], ?), F, A]): A =
     // NB: This is not implemented with [[matryoshka.distPara]] because that
     //     would add a [[matryoshka.Corecursive]] constraint.
     f(project(t) ∘ (t => (t, para(t)(f))))
 
-  def elgotPara[F[_]: Functor, A](t: T[F])(f: ((T[F], F[A])) => A): A =
+  def elgotPara[F[_]: Functor, A](t: T[F])(f: ElgotAlgebra[(T[F], ?), F, A]): A =
     // NB: This is not implemented with [[matryoshka.distPara]] because that
     //     would add a [[matryoshka.Corecursive]] constraint.
     f((t, project(t) ∘ (elgotPara(_)(f))))
 
-  def paraM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: F[(T[F], A)] => M[A]):
+  def paraM[F[_]: Traverse, M[_]: Monad, A](t: T[F])(f: GAlgebraM[(T[F], ?), M, F, A]):
       M[A] =
     project(t).traverse(v => paraM(v)(f) ∘ ((v, _))).flatMap(f)
 
   def gpara[F[_]: Functor, W[_]: Comonad, A](
     t: T[F])(
-    e: DistributiveLaw[F, W], f: F[EnvT[T[F], W, A]] => A)(
+    e: DistributiveLaw[F, W], f: GAlgebra[EnvT[T[F], W, ?], F, A])(
     implicit T: Corecursive[T]):
       A =
     gzygo[F, W, A, T[F]](t)(T.embed(_), e, f)
 
-  def zygo[F[_]: Functor, A, B](t: T[F])(f: F[B] => B, g: F[(B, A)] => A): A =
+  def zygo[F[_]: Functor, A, B](t: T[F])(f: Algebra[F, B], g: GAlgebra[(B, ?), F, A]): A =
     gcata[(B, ?), F, A](t)(distZygo(f), g)
 
-  def elgotZygo[F[_]: Functor, A, B](t: T[F])(f: F[B] => B, g: ElgotAlgebra[(B, ?), F, A]):
+  def elgotZygo[F[_]: Functor, A, B](t: T[F])(f: Algebra[F, B], g: ElgotAlgebra[(B, ?), F, A]):
       A =
     elgotCata[(B, ?), F, A](t)(distZygo(f), g)
 
   def gzygo[F[_]: Functor, W[_]: Comonad, A, B](
     t: T[F])(
-    f: F[B] => B, w: DistributiveLaw[F, W], g: F[EnvT[B, W, A]] => A):
+    f: Algebra[F, B], w: DistributiveLaw[F, W], g: GAlgebra[EnvT[B, W, ?], F, A]):
       A =
     gcata[EnvT[B, W, ?], F, A](t)(distZygoT(f, w), g)
 
@@ -107,16 +107,16 @@ import simulacrum.typeclass
     elgotCata[EnvT[B, W, ?], F, A](t)(distZygoT(f, w), g)
 
   /** Mutually-recursive fold. */
-  def mutu[F[_]: Functor, A, B](t: T[F])(f: F[(A, B)] => B, g: F[(B, A)] => A):
+  def mutu[F[_]: Functor, A, B](t: T[F])(f: GAlgebra[(A, ?), F, B], g: GAlgebra[(B, ?), F, A]):
       A =
     g(project(t) ∘ (x => (mutu(x)(g, f), mutu(x)(f, g))))
 
-  def prepro[F[_]: Functor, A](t: T[F])(e: F ~> F, f: F[A] => A)(implicit T: Corecursive[T]): A =
+  def prepro[F[_]: Functor, A](t: T[F])(e: F ~> F, f: Algebra[F, A])(implicit T: Corecursive[T]): A =
     f(project(t) ∘ (x => prepro(cata[F, T[F]](x)(c => T.embed(e(c))))(e, f)))
 
   def gprepro[F[_]: Functor, W[_]: Comonad, A](
     t: T[F])(
-    k: DistributiveLaw[F, W], e: F ~> F, f: F[W[A]] => A)(
+    k: DistributiveLaw[F, W], e: F ~> F, f: GAlgebra[W, F, A])(
     implicit T: Corecursive[T]):
       A = {
     def loop(t: T[F]): W[A] =
@@ -125,22 +125,22 @@ import simulacrum.typeclass
     loop(t).copoint
   }
 
-  def histo[F[_]: Functor, A](t: T[F])(f: F[Cofree[F, A]] => A): A =
+  def histo[F[_]: Functor, A](t: T[F])(f: GAlgebra[Cofree[F, ?], F, A]): A =
     gcata[Cofree[F, ?], F, A](t)(distHisto, f)
 
-  def elgotHisto[F[_]: Functor, A](t: T[F])(f: Cofree[F, F[A]] => A): A =
+  def elgotHisto[F[_]: Functor, A](t: T[F])(f: ElgotAlgebra[Cofree[F, ?], F, A]): A =
     elgotCata[Cofree[F, ?], F, A](t)(distHisto, f)
 
   def ghisto[F[_]: Functor, H[_]: Functor, A](
     t: T[F])(
-    g: DistributiveLaw[F, H], f: F[Cofree[H, A]] => A):
+    g: DistributiveLaw[F, H], f: GAlgebra[Cofree[H, ?], F, A]):
       A =
     gcata[Cofree[H, ?], F, A](t)(distGHisto(g), f)
 
   def paraZygo[F[_]:Functor: Unzip, A, B](
     t: T[F]) (
-    f: F[(T[F], B)] => B,
-    g: F[(B, A)] => A):
+    f: GAlgebra[(T[F], ?), F, B],
+    g: GAlgebra[(B, ?), F, A]):
       A = {
     def h(t: T[F]): (B, A) =
       (project(t) ∘ { x =>

--- a/core/shared/src/main/scala/matryoshka/TraverseT.scala
+++ b/core/shared/src/main/scala/matryoshka/TraverseT.scala
@@ -34,10 +34,10 @@ import simulacrum.typeclass
       M[T[F]] =
     f(t).flatMap(traverse(_)(_.traverse(transAnaTM(_)(f))))
 
-  def transCataM[M[_]: Monad, F[_]: Traverse, G[_]: Functor](t: T[F])(f: F[T[G]] => M[G[T[G]]]): M[T[G]] =
+  def transCataM[M[_]: Monad, F[_]: Traverse, G[_]: Functor](t: T[F])(f: AlgebraicTransformM[T, M, F, G]): M[T[G]] =
     traverse(t)(_.traverse(transCataM(_)(f)).flatMap(f))
 
-  def transAnaM[M[_]: Monad, F[_]: Functor, G[_]: Traverse](t: T[F])(f: F[T[F]] => M[G[T[F]]]): M[T[G]] =
+  def transAnaM[M[_]: Monad, F[_]: Functor, G[_]: Traverse](t: T[F])(f: CoalgebraicTransformM[T, M, F, G]): M[T[G]] =
     traverse(t)(f(_).flatMap(_.traverse(transAnaM(_)(f))))
 
   def topDownCataM[F[_]: Traverse, M[_]: Monad, A](

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -36,6 +36,109 @@ import scalaz._, Scalaz._
   */
 package object matryoshka extends CofreeInstances with FreeInstances {
 
+  /** Fold a structure `F` containing values in `W`, to a value `A`, 
+    * accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type GAlgebraM[W[_], M[_], F[_], A] = F[W[A]] => M[A]
+  /** Fold a structure `F` containing values in `W`, to a value `A`.
+    * @group algebras 
+    */
+  type GAlgebra[W[_], F[_], A]        = F[W[A]] => A    // GAlgebraM[W, Id, F, A]
+  /** Fold a structure `F` to a value `A`, accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type AlgebraM[M[_], F[_], A]        = F[A]    => M[A] // GAlgebraM[Id, M, F, A]
+  /** Fold a structure `F` to a value `A`.
+    * @group algebras 
+    */
+  type Algebra[F[_], A]               = F[A] => A       // GAlgebra[Id, F, A]
+  /** Fold a structure `F` (usually a `Functor`) contained in `W` (usually a 
+    * `Comonad`), to a value `A`, accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type ElgotAlgebraM[W[_], M[_], F[_], A] =                        W[F[A]] => M[A]
+  /** Fold a structure `F` (usually a `Functor`) contained in `W` (usually a 
+    * `Comonad`), to a value `A`.
+    * @group algebras 
+    */
+  type ElgotAlgebra[W[_], F[_], A] = ElgotAlgebraM[W, Id, F, A] // W[F[A]] => A
+
+  /** Unfold a value `A` to a structure `F` containing values in `N`, 
+    * accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type GCoalgebraM[N[_], M[_], F[_], A] = A => M[F[N[A]]]
+  /** Unfold a value `A` to a structure `F` containing values in `N`.
+    * @group algebras 
+    */
+  type GCoalgebra[N[_], F[_], A]        = A => F[N[A]] // GCoalgebraM[N, Id, F, A]
+  /** Unfold a value `A` to a structure `F`, accumulating effects in the monad 
+    * `M`.
+    * @group algebras 
+    */
+  type CoalgebraM[M[_], F[_], A]        = A => M[F[A]] // GCoalgebraM[Id, M, F, A]
+  /** Unfold a value `A` to a structure `F`.
+    * @group algebras 
+    */
+  type Coalgebra[F[_], A]               = A => F[A]    // GCoalgebra[Id, F, A]
+  /** Unfold a value `A` to a structure `F` (usually a `Functor`), contained in 
+    * `E`, accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type ElgotCoalgebraM[E[_], M[_], F[_], A] = A => M[E[F[A]]]
+  /** Unfold a value `A` to a structure `F` (usually a `Functor`), contained in 
+    * `E`.
+    * @group algebras 
+    */
+  type ElgotCoalgebra[E[_], F[_], A]        = A => E[F[A]] // ElgotCoalgebraM[E, Id, F, A]
+
+  /** Transform a structure `F` containing values in `W`, to a structure `G`, 
+    * in bottom-up fashion, accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type GAlgebraicTransformM[T[_[_]], W[_], M[_], F[_], G[_]] = F[W[T[G]]] => M[G[T[G]]]
+  /** Transform a structure `F`, to a structure `G`, in bottom-up fashion, 
+    * accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type AlgebraicTransformM[T[_[_]], M[_], F[_], G[_]]        = F[T[G]] => M[G[T[G]]] // GAlgebraicTransformM[T, Id, M, F, G]
+  /** Transform a structure `F` containing values in `W`, to a structure `G`, 
+    * in bottom-up fashion.
+    * @group algebras 
+    */
+  type GAlgebraicTransform[T[_[_]], W[_], F[_], G[_]]        = F[W[T[G]]] => G[T[G]] // GAlgebraicTransformM[T, W, Id, F, G]
+  /** Transform a structure `F` to a structure `G`, in bottom-up fashion.
+    * @group algebras 
+    */
+  type AlgebraicTransform[T[_[_]], F[_], G[_]]               = F[T[G]] => G[T[G]]    // GAlgebraicTransformM[T, Id, Id, F, G]
+
+  /** Transform a structure `F` to a structure `G` containing values in `N`, 
+    * in top-down fashion, accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type GCoalgebraicTransformM[T[_[_]], N[_], M[_], F[_], G[_]] = F[T[F]] => M[G[N[T[F]]]]
+  /** Transform a structure `F` to a structure `G`, in top-down fashion, 
+    * accumulating effects in the monad `M`.
+    * @group algebras 
+    */
+  type CoalgebraicTransformM[T[_[_]], M[_], F[_], G[_]]        = F[T[F]] => M[G[T[F]]] // GCoalgebraicTransformM[T, Id, M, F, G]
+  /** Transform a structure `F` to a structure `G` containing values in `N`, 
+    * in top-down fashion.
+    * @group algebras 
+    */
+  type GCoalgebraicTransform[T[_[_]], N[_], F[_], G[_]]        = F[T[F]] => G[N[T[F]]] // GCoalgebraicTransformM[T, N, Id, F, G]
+  /** Transform a structure `F` to a structure `G`, in top-down fashion.
+    * @group algebras 
+    */
+  type CoalgebraicTransform[T[_[_]], F[_], G[_]]               = F[T[F]] => G[T[F]]    // GCoalgebraicTransformM[T, Id, Id, F, G]
+
+  /** @group algtrans */
+  def transformToAlgebra[T[_[_]]: Corecursive, W[_], M[_]: Functor, F[_], G[_]: Functor](
+    self: GAlgebraicTransformM[T, W, M, F, G]):
+      GAlgebraM[W, M, F, T[G]] =
+    self(_) ∘ (_.embed)
+
   def lambek[T[_[_]]: Corecursive: Recursive, F[_]: Functor](tf: T[F]):
       F[T[F]] =
     tf.cata[F[T[F]]](_ ∘ (_.embed))
@@ -43,59 +146,6 @@ package object matryoshka extends CofreeInstances with FreeInstances {
   def colambek[T[_[_]]: Corecursive: Recursive, F[_]: Functor](ft: F[T[F]]):
       T[F] =
     ft.ana(_ ∘ (_.project))
-
-  /** @group algebras */
-  type GAlgebraM[W[_], M[_], F[_], A] =                    F[W[A]] => M[A]
-  /** @group algebras */
-  type GAlgebra[W[_], F[_], A] = GAlgebraM[W, Id, F, A] // F[W[A]] => A
-  /** @group algebras */
-  type AlgebraM[M[_], F[_], A] = GAlgebraM[Id, M, F, A] // F[A]    => M[A]
-  /** @group algebras */
-  type Algebra[F[_], A]        = F[A] => A              // GAlgebra[Id, F, A], but defining it directly avoids a "cyclic aliasing" error
-  /** @group algebras */
-  type ElgotAlgebraM[W[_], M[_], F[_], A] =                        W[F[A]] => M[A]
-  /** @group algebras */
-  type ElgotAlgebra[W[_], F[_], A] = ElgotAlgebraM[W, Id, F, A] // W[F[A]] => A
-
-  /** @group algebras */
-  type GCoalgebraM[N[_], M[_], F[_], A] =                      A => M[F[N[A]]]
-  /** @group algebras */
-  type GCoalgebra[N[_], F[_], A] = A => F[N[A]]             // GCoalgebraM[N, Id, F, A], but defining it avoids some type ascriptions
-  /** @group algebras */
-  type CoalgebraM[M[_], F[_], A] = GCoalgebraM[Id, M, F, A] // A => M[F[A]]
-  /** @group algebras */
-  type Coalgebra[F[_], A]        = A => F[A]                // GCoalgebra[Id, F, A], but defining it avoids some type ascriptions
-  /** @group algebras */
-  type ElgotCoalgebraM[E[_], M[_], F[_], A] =                          A => M[E[F[A]]]
-  /** @group algebras */
-  type ElgotCoalgebra[E[_], F[_], A] = ElgotCoalgebraM[E, Id, F, A] // A => E[F[A]]
-
-  /** @group algebras */
-  type GAlgebraicTransformM[T[_[_]], W[_], M[_], F[_], G[_]] = F[W[T[G]]] => M[G[T[G]]]
-  /** @group algebras */
-  type AlgebraicTransformM[T[_[_]], M[_], F[_], G[_]] = GAlgebraicTransformM[T, Id, M, F, G]
-  /** @group algebras */
-  type GAlgebraicTransform[T[_[_]], W[_], F[_], G[_]] = GAlgebraicTransformM[T, W, Id, F, G]
-  /** @group algebras */
-  type AlgebraicTransform[T[_[_]], F[_], G[_]] = GAlgebraicTransformM[T, Id, Id, F, G]
-
-  /** @group algebras */
-  type GCoalgebraicTransformM[T[_[_]], M[_], N[_], F[_], G[_]] = F[T[F]] => N[G[M[T[F]]]]
-  /** @group algebras */
-  type CoalgebraicTransformM[T[_[_]], N[_], F[_], G[_]] = GCoalgebraicTransformM[T, Id, N, F, G]
-  /** @group algebras */
-  type GCoalgebraicTransform[T[_[_]], M[_], F[_], G[_]] = GCoalgebraicTransformM[T, M, Id, F, G]
-  /** @group algebras */
-  type CoalgebraicTransform[T[_[_]], F[_], G[_]] = GCoalgebraicTransformM[T, Id, Id, F, G]
-
-  /**
-    *
-    * @group algtrans
-    */
-  def transformToAlgebra[T[_[_]]: Corecursive, W[_], M[_]: Functor, F[_], G[_]: Functor](
-    self: GAlgebraicTransformM[T, W, M, F, G]):
-      GAlgebraM[W, M, F, T[G]] =
-    self(_) ∘ (_.embed)
 
   /** An algebra and its dual form an isomorphism.
     */


### PR DESCRIPTION
I think makes it easier to compare the different types of (co)algebras, largely by forcing the user to go look at the definitions until they make sense.

This also cleans up some misleading comments and inconsistent use of `N` as opposed to `M`, which helps to reduce confusion.

I had a go at writing a "plain English" scaladoc description of each alias. Along with defining each one directly, that makes it much easier to see the intended purpose of each, and how they compare. But feel free to object to the terms I used in those descriptions and I'll improve them.