### PR TITLE
Move fixed-point datatypes to their own package.

### DIFF
--- a/CHANGELOG/breaking.md
+++ b/CHANGELOG/breaking.md
@@ -1,0 +1,1 @@
+- Move fixed-point datatypes to their own package.

--- a/core/jvm/src/test/scala/matryoshka/data/fix.scala
+++ b/core/jvm/src/test/scala/matryoshka/data/fix.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
 
 import matryoshka.exp.Exp
 import matryoshka.helpers._

--- a/core/jvm/src/test/scala/matryoshka/data/mu.scala
+++ b/core/jvm/src/test/scala/matryoshka/data/mu.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
 
 import matryoshka.exp.Exp
 import matryoshka.helpers._

--- a/core/jvm/src/test/scala/matryoshka/data/nu.scala
+++ b/core/jvm/src/test/scala/matryoshka/data/nu.scala
@@ -14,23 +14,25 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
 
-import scalaz._
+import matryoshka.exp.Exp
+import matryoshka.helpers._
+import matryoshka.patterns.CoEnv
+import matryoshka.specs2.scalacheck._
 
-/** This is the simplest fixpoint type, implemented with general recursion.
-  */
-final case class Fix[F[_]](unFix: F[Fix[F]])
-object Fix {
-  implicit val recursive: Recursive[Fix] = new Recursive[Fix] {
-    def project[F[_]: Functor](t: Fix[F]) = t.unFix
+import scala.Int
+
+import org.specs2.mutable._
+import scalaz._, Scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+class NuSpec extends Specification with CheckAll with AlgebraChecks {
+  "Nu" should {
+    "satisfy relevant laws" in {
+      checkAll(equal.laws[Nu[Exp]])
+    }
   }
 
-  implicit val corecursive: Corecursive[Fix] = new Corecursive[Fix] {
-    def embed[F[_]: Functor](t: F[Fix[F]]) = Fix(t)
-  }
-
-  implicit val equalT: EqualT[Fix] = Recursive.equalT[Fix]
-
-  implicit val showT: ShowT[Fix] = Recursive.showT[Fix]
+  checkFoldIsoLaws[Nu, CoEnv[Int, Exp, ?], Free[Exp, Int]]("Nu", CoEnv.freeIso)
 }

--- a/core/jvm/src/test/scala/matryoshka/exp/package.scala
+++ b/core/jvm/src/test/scala/matryoshka/exp/package.scala
@@ -16,6 +16,8 @@
 
 package matryoshka
 
+import matryoshka.data.Fix
+
 import scala.{Int, Symbol}
 
 package object exp {

--- a/core/jvm/src/test/scala/matryoshka/exp2/package.scala
+++ b/core/jvm/src/test/scala/matryoshka/exp2/package.scala
@@ -16,6 +16,8 @@
 
 package matryoshka
 
+import matryoshka.data.Fix
+
 import scala.Int
 
 package object exp2 {

--- a/core/jvm/src/test/scala/matryoshka/instances/fixedpoint/nat.scala
+++ b/core/jvm/src/test/scala/matryoshka/instances/fixedpoint/nat.scala
@@ -17,6 +17,7 @@
 package matryoshka.instances.fixedpoint
 
 import matryoshka._, Recursive.ops._
+import matryoshka.data.Mu
 import matryoshka.helpers._
 
 import scala.Option

--- a/core/jvm/src/test/scala/matryoshka/instances/fixedpoint/stream.scala
+++ b/core/jvm/src/test/scala/matryoshka/instances/fixedpoint/stream.scala
@@ -17,6 +17,7 @@
 package matryoshka.instances.fixedpoint
 
 import matryoshka._
+import matryoshka.data.Nu
 
 import scala.Int
 

--- a/core/jvm/src/test/scala/matryoshka/patterns/coenv.scala
+++ b/core/jvm/src/test/scala/matryoshka/patterns/coenv.scala
@@ -17,6 +17,7 @@
 package matryoshka.patterns
 
 import matryoshka._
+import matryoshka.data._
 import matryoshka.exp.Exp
 import matryoshka.exp2.Exp2
 import matryoshka.helpers._

--- a/core/jvm/src/test/scala/matryoshka/patterns/diff.scala
+++ b/core/jvm/src/test/scala/matryoshka/patterns/diff.scala
@@ -17,6 +17,7 @@
 package matryoshka.patterns
 
 import matryoshka._, Recursive.ops._
+import matryoshka.data.Mu
 import matryoshka.example._
 import matryoshka.exp._
 import matryoshka.helpers._

--- a/core/jvm/src/test/scala/matryoshka/patterns/potentialFailure.scala
+++ b/core/jvm/src/test/scala/matryoshka/patterns/potentialFailure.scala
@@ -17,6 +17,7 @@
 package matryoshka.patterns
 
 import matryoshka._
+import matryoshka.data.Fix
 import matryoshka.exp._
 import matryoshka.helpers._
 import matryoshka.specs2.scalacheck.CheckAll

--- a/core/jvm/src/test/scala/matryoshka/runners/package.scala
+++ b/core/jvm/src/test/scala/matryoshka/runners/package.scala
@@ -17,6 +17,7 @@
 package matryoshka
 
 import Recursive.ops._
+import matryoshka.data._
 
 import scala.Unit
 import scala.Predef.implicitly

--- a/core/jvm/src/test/scala/matryoshka/spec.scala
+++ b/core/jvm/src/test/scala/matryoshka/spec.scala
@@ -17,6 +17,7 @@
 package matryoshka
 
 import Recursive.ops._, FunctorT.ops._, TraverseT.nonInheritedOps._
+import matryoshka.data._
 import matryoshka.exp._
 import matryoshka.exp2._
 import matryoshka.helpers._

--- a/core/shared/src/main/scala/matryoshka/data/Fix.scala
+++ b/core/shared/src/main/scala/matryoshka/data/Fix.scala
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
 
-import matryoshka.exp.Exp
-import matryoshka.helpers._
-import matryoshka.patterns.CoEnv
-import matryoshka.specs2.scalacheck._
+import matryoshka._
 
-import scala.Int
+import scalaz._
 
-import org.specs2.mutable._
-import scalaz._, Scalaz._
-import scalaz.scalacheck.ScalazProperties._
-
-class NuSpec extends Specification with CheckAll with AlgebraChecks {
-  "Nu" should {
-    "satisfy relevant laws" in {
-      checkAll(equal.laws[Nu[Exp]])
-    }
+/** This is the simplest fixpoint type, implemented with general recursion.
+  */
+final case class Fix[F[_]](unFix: F[Fix[F]])
+object Fix {
+  implicit val recursive: Recursive[Fix] = new Recursive[Fix] {
+    def project[F[_]: Functor](t: Fix[F]) = t.unFix
   }
 
-  checkFoldIsoLaws[Nu, CoEnv[Int, Exp, ?], Free[Exp, Int]]("Nu", CoEnv.freeIso)
+  implicit val corecursive: Corecursive[Fix] = new Corecursive[Fix] {
+    def embed[F[_]: Functor](t: F[Fix[F]]) = Fix(t)
+  }
+
+  implicit val equalT: EqualT[Fix] = Recursive.equalT[Fix]
+
+  implicit val showT: ShowT[Fix] = Recursive.showT[Fix]
 }

--- a/core/shared/src/main/scala/matryoshka/data/Mu.scala
+++ b/core/shared/src/main/scala/matryoshka/data/Mu.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
 
-import Recursive.ops._
+import matryoshka._, Recursive.ops._
 
 import scalaz._, Scalaz._
 

--- a/core/shared/src/main/scala/matryoshka/data/Nu.scala
+++ b/core/shared/src/main/scala/matryoshka/data/Nu.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
+
+import matryoshka._
 
 import scalaz._, Scalaz._
 

--- a/core/shared/src/main/scala/matryoshka/data/cofree.scala
+++ b/core/shared/src/main/scala/matryoshka/data/cofree.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
+
+import matryoshka._
 
 import scalaz._
 import scalaz.syntax.functor._

--- a/core/shared/src/main/scala/matryoshka/data/free.scala
+++ b/core/shared/src/main/scala/matryoshka/data/free.scala
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package matryoshka
+package matryoshka.data
+
+import matryoshka._
 
 import scalaz._, Scalaz._
 

--- a/core/shared/src/main/scala/matryoshka/data/package.scala
+++ b/core/shared/src/main/scala/matryoshka/data/package.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014–2016 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import scalaz._, Scalaz._
+
+package object data extends CofreeInstances with FreeInstances {
+
+  def cofParaM[M[_]] = new CofParaMPartiallyApplied[M]
+  final class CofParaMPartiallyApplied[M[_]] { self =>
+    def apply[T[_[_]]: Corecursive, S[_]: Traverse, A, B](t: Cofree[S, A])(f: (A, S[(T[S], B)]) => M[B])(implicit M: Monad[M]): M[B] =
+      t.tail.traverse(cs => self(cs)(f) ∘ ((Recursive[Cofree[?[_], A]].convertTo[S, T](cs), _))) >>= (f(t.head, _))
+  }
+
+  /** NB: Since Cofree carries the functor, the resulting algebra is a cata, not
+    *     a para.
+    *
+    * @group algtrans
+    */
+  def attributePara[T[_[_]]: Corecursive, F[_]: Functor, A](f: GAlgebra[(T[F], ?), F, A]):
+      Algebra[F, Cofree[F, A]] =
+    fa => Cofree(f(fa ∘ (x => (Recursive[Cofree[?[_], A]].convertTo[F, T](x), x.head))), fa)
+}

--- a/core/shared/src/main/scala/matryoshka/instances/fixedpoint/package.scala
+++ b/core/shared/src/main/scala/matryoshka/instances/fixedpoint/package.scala
@@ -17,6 +17,7 @@
 package matryoshka.instances
 
 import matryoshka._, Recursive.ops._
+import matryoshka.data._
 import matryoshka.patterns._
 
 import monocle.Prism

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -34,7 +34,7 @@ import scalaz._, Scalaz._
   * @groupname dist Distributive Laws
   * @groupdesc dist Natural transformations required for generalized folds and unfolds.
   */
-package object matryoshka extends CofreeInstances with FreeInstances {
+package object matryoshka {
 
   /** Fold a structure `F` containing values in `W`, to a value `A`, 
     * accumulating effects in the monad `M`.
@@ -241,12 +241,6 @@ package object matryoshka extends CofreeInstances with FreeInstances {
     ψ(a).fold(
       _.point[Free[F, ?]],
       fb => Free.liftF(fb ∘ (freeAna(_)(ψ))).join)
-
-  def cofParaM[M[_]] = new CofParaMPartiallyApplied[M]
-  final class CofParaMPartiallyApplied[M[_]] { self =>
-    def apply[T[_[_]]: Corecursive, S[_]: Traverse, A, B](t: Cofree[S, A])(f: (A, S[(T[S], B)]) => M[B])(implicit M: Monad[M]): M[B] =
-      t.tail.traverse(cs => self(cs)(f) ∘ ((Recursive[Cofree[?[_], A]].convertTo[S, T](cs), _))) >>= (f(t.head, _))
-  }
 
   /** Composition of an anamorphism and a catamorphism that avoids building the
     * intermediate recursive data structure.
@@ -572,15 +566,6 @@ package object matryoshka extends CofreeInstances with FreeInstances {
     */
   def attrSelf[T[_[_]]: Corecursive, F[_]: Functor] =
     attributeAlgebra[F, T[F]](_.embed)
-
-  /** NB: Since Cofree carries the functor, the resulting algebra is a cata, not
-    *     a para.
-    *
-    * @group algtrans
-    */
-  def attributePara[T[_[_]]: Corecursive, F[_]: Functor, A](f: GAlgebra[(T[F], ?), F, A]):
-      Algebra[F, Cofree[F, A]] =
-    fa => Cofree(f(fa ∘ (x => (Recursive[Cofree[?[_], A]].convertTo[F, T](x), x.head))), fa)
 
   /** A function to be called like `attributeElgotM[M](myElgotAlgebraM)`.
     *

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12


### PR DESCRIPTION
This adds a _little_ more friction in order to encourage the use of type
class constraints rather than hard-coding a particular type.