### PR TITLE
Update the parts of the build which are easy to update.

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- Build updates: kind-projector, simulacrum.

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val standardSettings = Seq(
     "JBoss repository" at "https://repository.jboss.org/nexus/content/repositories/",
     "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
     "bintray/non" at "http://dl.bintray.com/non/maven"),
-  addCompilerPlugin("org.spire-math" %% "kind-projector"   % "0.7.1"),
+  addCompilerPlugin("org.spire-math" %% "kind-projector"   % "0.9.2"),
   addCompilerPlugin("org.scalamacros" % "paradise"         % "2.1.0" cross CrossVersion.full),
   addCompilerPlugin("com.milessabin"  % "si2712fix-plugin" % "1.2.0" cross CrossVersion.full),
   ScoverageKeys.coverageHighlighting := true,

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val standardSettings = Seq(
   libraryDependencies ++= Seq(
     "com.github.julien-truffaut" %%% "monocle-core" % monocleVersion % "compile, test",
     "org.scalaz"                 %%% "scalaz-core"  % scalazVersion  % "compile, test",
-    "com.github.mpilquist"       %%% "simulacrum"   % "0.7.0"        % "compile, test"),
+    "com.github.mpilquist"       %%% "simulacrum"   % "0.10.0"       % "compile, test"),
 
   licenses += ("Apache 2", url("http://www.apache.org/licenses/LICENSE-2.0")),
 

--- a/core/shared/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Corecursive.scala
@@ -17,11 +17,9 @@
 package matryoshka
 
 import Recursive.ops._
-
-import scala.{inline, Predef}
-
+import scala.Predef
 import scalaz._, Scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 /** Unfolds for corecursive data types. */
 @typeclass trait Corecursive[T[_[_]]] {

--- a/core/shared/src/main/scala/matryoshka/EqualT.scala
+++ b/core/shared/src/main/scala/matryoshka/EqualT.scala
@@ -16,10 +16,9 @@
 
 package matryoshka
 
-import scala.{Boolean, inline}
-
+import scala.Boolean
 import scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 @typeclass trait EqualT[T[_[_]]] {
   def equal[F[_]: Functor](tf1: T[F], tf2: T[F])(implicit del: Delay[Equal, F]):

--- a/core/shared/src/main/scala/matryoshka/FunctorT.scala
+++ b/core/shared/src/main/scala/matryoshka/FunctorT.scala
@@ -16,10 +16,9 @@
 
 package matryoshka
 
-import scala.{inline, Predef}
-
+import scala.Predef
 import scalaz._, Scalaz._
-import simulacrum.{typeclass}
+import simulacrum._
 
 /** The operations here are very similar to those in Recursive and Corecursive.
   * The usual names (`cata`, `ana`, etc.) are prefixed with `trans` and behave

--- a/core/shared/src/main/scala/matryoshka/Merge.scala
+++ b/core/shared/src/main/scala/matryoshka/Merge.scala
@@ -16,9 +16,8 @@
 
 package matryoshka
 
-import scala.{inline, None, Option, Unit}
-
-import simulacrum.typeclass
+import scala.{None, Option, Unit}
+import simulacrum._
 import scalaz._, Scalaz._
 
 /** Like `Zip`, but it can fail to merge, so it’s much more general.

--- a/core/shared/src/main/scala/matryoshka/Recursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Recursive.scala
@@ -19,11 +19,11 @@ package matryoshka
 import Merge.ops._
 import matryoshka.patterns.EnvT
 
-import scala.{Boolean, inline, Option, PartialFunction}
+import scala.{Boolean, Option, PartialFunction}
 import scala.collection.immutable.{List, Nil}
 
 import scalaz._, Scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 /** Folds for recursive data types. */
 @typeclass trait Recursive[T[_[_]]] {

--- a/core/shared/src/main/scala/matryoshka/ShowT.scala
+++ b/core/shared/src/main/scala/matryoshka/ShowT.scala
@@ -17,10 +17,8 @@
 package matryoshka
 
 import java.lang.String
-import scala.inline
-
 import scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 @typeclass trait ShowT[T[_[_]]] {
   def show[F[_]: Functor](tf: T[F])(implicit del: Delay[Show, F]): Cord =

--- a/core/shared/src/main/scala/matryoshka/TraverseT.scala
+++ b/core/shared/src/main/scala/matryoshka/TraverseT.scala
@@ -16,10 +16,8 @@
 
 package matryoshka
 
-import scala.inline
-
 import scalaz._, Scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 @typeclass trait TraverseT[T[_[_]]] extends FunctorT[T] {
   def traverse[M[_]: Applicative, F[_]: Functor, G[_]: Functor](t: T[F])(f: F[T[F]] => M[G[T[G]]]):

--- a/core/shared/src/main/scala/matryoshka/patterns/Diffable.scala
+++ b/core/shared/src/main/scala/matryoshka/patterns/Diffable.scala
@@ -18,10 +18,9 @@ package matryoshka.patterns
 
 import matryoshka._
 
-import scala.{inline, Option}
-
+import scala.Option
 import scalaz._, Scalaz._
-import simulacrum.typeclass
+import simulacrum._
 
 @typeclass trait Diffable[F[_]] { self =>
   def diffImpl[T[_[_]]: Recursive: Corecursive](l: T[F], r: T[F]):

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,13 @@
 resolvers += "Jenkins-CI" at "http://repo.jenkins-ci.org/repo"
-libraryDependencies += "org.kohsuke" % "github-api" % "1.59"
+libraryDependencies += "org.kohsuke" % "github-api" % "1.77"
 
-addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "1.5.0")
+addSbtPlugin("de.heikoseeberger"     % "sbt-header"      % "1.6.0")
 addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar"      % "0.8")
 addSbtPlugin("com.jsuereth"          % "sbt-pgp"         % "1.0.0")
-addSbtPlugin("com.github.gseitz"     % "sbt-release"     % "1.0.0")
-addSbtPlugin("org.scala-js"          % "sbt-scalajs"     % "0.6.9")
-addSbtPlugin("org.scoverage"         % "sbt-scoverage"   % "1.3.3")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-site"        % "1.0.0")
+addSbtPlugin("com.github.gseitz"     % "sbt-release"     % "1.0.3")
+addSbtPlugin("org.scala-js"          % "sbt-scalajs"     % "0.6.13")
+addSbtPlugin("org.scoverage"         % "sbt-scoverage"   % "1.4.0")
+addSbtPlugin("com.typesafe.sbt"      % "sbt-site"        % "1.1.0")
 addSbtPlugin("com.eed3si9n"          % "sbt-unidoc"      % "0.3.3")
 addSbtPlugin("org.brianmckenna"      % "sbt-wartremover" % "0.14")
+addSbtPlugin("io.get-coursier"       % "sbt-coursier"    % "1.0.0-M14")


### PR DESCRIPTION
I've been letting difficult upgrades stand in the way
of easy ones which I really need. Let's stop doing that.
This updates simulacrum to 0.10.0 and kind-projector
to 0.9.2. Everything which wasn't upgraded was left
alone for good reason.