### PR TITLE
Fix example in README.md

### DIFF
--- a/CHANGELOG/revision.md
+++ b/CHANGELOG/revision.md
@@ -1,0 +1,1 @@
+- fixed example in README.md

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ This diagram covers the major classes of transformations. The most basic ones ar
 Here is a very simple example of an algebra (`eval`) and how to apply it to a recursive structure.
 
 ```scala
-
-// we will need a Functor[Expr] in order to call embedT bellow
+// we will need a Functor[Expr] in order to call embed bellow
 implicit val exprFunctor = new scalaz.Functor[Expr] {
   override def map[A, B](fa: Expr[A])(f: (A) => B) = fa match{
     case Num(value) => Num[B](value)

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ val eval: Algebra[Expr, Long] = { // i.e. Expr[Long] => Long
   case Mul(x, y) => x * y
 }
  
-def someExpr[T[_[_]]: CorecursiveT]: T[Expr] =
-  Mul(Num[T[Expr]](2).embedT, Mul(Num[T[Expr]](3).embedT,
-      Num[T[Expr]](4).embedT).embedT).embedT
+def someExpr[T](implicit T: Corecursive.Aux[T, Expr]): T =
+  Mul(Num[T](2).embed, Mul(Num[T](3).embed,
+      Num[T](4).embed).embed).embed
 
 import matryoshka.data.Mu 
 
-someExpr[Mu].cata(eval) // ⇒ 24
+someExpr[Mu[Expr]].cata(eval) // ⇒ 24
 ```
 
 The `.embed` calls in `someExpr` wrap the nodes in the fixed point type. `embed` is generic, and we abstract `someExpr` over the fixed point type (only requiring that it has an instance of `Corecursive`), so we can postpone the choice of the fixed point as long as possible.


### PR DESCRIPTION
The example in README.md wasn't compiling against the latest published version (0.15.1).

The necessary functor could be freer but honestly, I don't know how to use Coyoneda to grab a free functor.

I switched to `CorecursiveT` because it aligns with the `T[_[_]]` needed here, whereas `Corecursive`doesn't.

This was an attempt for me to understand what's going on here, but it wasn't completely successful. So please disregard this if it looks stupid.