### PR TITLE
Make RecursiveT serializable

### DIFF
--- a/core/shared/src/main/scala/matryoshka/RecursiveT.scala
+++ b/core/shared/src/main/scala/matryoshka/RecursiveT.scala
@@ -16,6 +16,7 @@
 
 package matryoshka
 
+import scala.Serializable
 import scalaz._, Scalaz._
 
 /** This is a workaround for a certain use case (e.g.,
@@ -23,7 +24,7 @@ import scalaz._, Scalaz._
   * Define an instance of this rather than [[Recursive]] when possible.
   */
 // NB: Not a `@typeclass` because we don’t want to inject these operations.
-trait RecursiveT[T[_[_]]] {
+trait RecursiveT[T[_[_]]] extends Serializable {
   def projectT[F[_]: Functor](t: T[F]): F[T[F]]
 
   def cataT[F[_]: Functor, A](t: T[F])(f: Algebra[F, A]): A =


### PR DESCRIPTION
I'm using Matryoshka on Spark. Becasue computation has to be send to
cluster over the network, whole code needs to serialize. Becasue
RecursiveT did not extend Serializable, this was not possible. This
commit changes that.