### PR TITLE
Make repeatedly tail-recursive

### DIFF
--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -641,7 +641,7 @@ package object matryoshka {
     *
     * @group algtrans
     */
-  @annotation.tailrec
+  @tailrec
   final def repeatedly[A](f: A => Option[A])(expr: A): A =
     f(expr) match {
       case None => expr

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -641,8 +641,12 @@ package object matryoshka {
     *
     * @group algtrans
     */
-  def repeatedly[A](f: A => Option[A]): A => A =
-    expr => f(expr).fold(expr)(repeatedly(f))
+  @annotation.tailrec
+  final def repeatedly[A](f: A => Option[A])(expr: A): A =
+    f(expr) match {
+      case None => expr
+      case Some(e) => repeatedly(f)(e)
+    }
 
   /** Converts a failable fold into a non-failable, by simply returning the
     * argument upon failure.


### PR DESCRIPTION
Now's the second time I've told someone to steal tail-recursive repeatedly from slate. Fixing at the source would be nicer.