### PR TITLE
Add monadic zygomorphism

### DIFF
--- a/core/shared/src/main/scala/matryoshka/implicits/AlgebraOps.scala
+++ b/core/shared/src/main/scala/matryoshka/implicits/AlgebraOps.scala
@@ -18,13 +18,18 @@ package matryoshka.implicits
 
 import matryoshka._
 
-import scalaz._
-import scalaz.syntax.comonad._
+import scalaz._, Scalaz._
 
 sealed class AlgebraOps[F[_], A](self: Algebra[F, A]) {
   def generalize[W[_]: Comonad](implicit F: Functor[F]): GAlgebra[W, F, A] =
     node => self(node ∘ (_.copoint))
 
+  def generalizeM[M[_]: Applicative](implicit F: Functor[F]): AlgebraM[M, F, A] =
+    node => self(node).point[M]
+
   def generalizeElgot[W[_]: Comonad]: ElgotAlgebra[W, F, A] =
     w => self(w.copoint)
+
+  def generalizeElgotM[W[_]: Comonad, M[_]: Monad]: ElgotAlgebraM[W, M, F, A] =
+    w => self(w.copoint).point[M]
 }

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -402,6 +402,18 @@ package object matryoshka {
     *
     * @group dist
     */
+  def distZygoM[F[_]: Functor, M[_]: Monad, B](
+    g: AlgebraM[M, F, B], k: DistributiveLaw[F, M]) =
+    new DistributiveLaw[F, (M ∘ (B, ?))#λ] {
+      def apply[α](fm: F[M[(B, α)]]) = {
+        k(fm) >>= { f => g(f ∘ (_._1)) ∘ ((_, f ∘ (_._2))) }
+      }
+    }
+
+  /**
+    *
+    * @group dist
+    */
   def distZygoT[F[_]: Functor, W[_]: Comonad, B](
     g: Algebra[F, B], k: DistributiveLaw[F, W]) =
     new DistributiveLaw[F, EnvT[B, W, ?]] {

--- a/tests/shared/src/test/scala/matryoshka/spec.scala
+++ b/tests/shared/src/test/scala/matryoshka/spec.scala
@@ -134,12 +134,6 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
       case _ => t.map(_.head).embed
     }
 
-  val eval: Algebra[Exp, Int] = {
-    case Num(x)    => x
-    case Mul(x, y) => x * y
-    case _         => ???
-  }
-
   checkAlgebraIsoLaws("recCorec", birecursiveIso[Mu[Exp], Exp])
   checkAlgebraIsoLaws("lambek", bilambekIso[Mu[Exp], Exp])
 
@@ -434,10 +428,6 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
         i.elgot(eval, extractFactors.generalizeElgot[Int \/ ?]) must equal(x)
       }
     }
-
-    def extractFactors: Coalgebra[Exp, Int] = x =>
-      if (x > 2 && x % 2 == 0) Mul(2, x/2)
-      else Num(x)
 
     "generalizeCoalgebra" >> {
       "behave like ana" ! prop { (i: Int) =>
@@ -746,25 +736,6 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
         i.ghylo[Cofree[Exp, ?], Free[Exp, ?]](
           distHisto, distFutu, partialEval[Fix[Exp]], extract2and3) must
           equal(i.chrono(partialEval[Fix[Exp]], extract2and3))
-      }
-    }
-
-    def strings(t: Exp[(Int, String)]): String = t match {
-      case Num(x) => x.toString
-      case Mul((x, xs), (y, ys)) =>
-        xs + " (" + x + ")" + ", " + ys + " (" + y + ")"
-      case _ => ???
-    }
-
-    "zygo" >> {
-      "eval and strings" in {
-        testRec(
-          mul(mul(num(0), num(0)), mul(num(2), num(5))),
-          new RecRunner[Exp, String] {
-            def run[T](implicit TR: Recursive.Aux[T, Exp], TC: Corecursive.Aux[T, Exp]) =
-              _.zygo(eval, strings) must
-                equal("0 (0), 0 (0) (0), 2 (2), 5 (5) (10)")
-          })
       }
     }
 

--- a/tests/shared/src/test/scala/matryoshka/zygoSpec.scala
+++ b/tests/shared/src/test/scala/matryoshka/zygoSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014–2017 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matryoshka
+
+import slamdata.Predef._
+import matryoshka.data._
+import matryoshka.exp._
+import matryoshka.helpers._
+import matryoshka.implicits._
+import matryoshka.runners._
+
+import org.scalacheck._, Prop._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import org.specs2.scalaz.ScalazMatchers
+import scalaz._, Scalaz._
+
+class ZygoSpecs extends Specification with ScalaCheck with ScalazMatchers {
+
+  def extractFactors2: Coalgebra[Exp, Int] = { x =>
+    def sqrt(x: Int): Int = scala.math.sqrt(x.toDouble).toInt
+
+    if (x > 1 && sqrt(x) * sqrt(x) == x) Mul(sqrt(x), sqrt(x))
+    else if (x > 2 && x % 2 == 0) Mul(2, x/2)
+    else Num(x)
+  }
+
+  "Recursive" >> {
+    "zygo" >> {
+      "eval and strings" in {
+        testRec(
+          mul(mul(num(0), num(0)), mul(num(2), num(5))),
+          new RecRunner[Exp, String] {
+            def run[T](implicit TR: Recursive.Aux[T, Exp], TC: Corecursive.Aux[T, Exp]) =
+              _.zygo(eval, strings) must
+            equal("0 (0), 0 (0) (0), 2 (2), 5 (5) (10)")
+          })
+      }
+    }
+
+    "zygoM" >> {
+      "behave like zygo" >> prop { (i: Int) =>
+        val factors = i.ana[Fix[Exp]](extractFactors)
+
+        val a = factors.zygo(eval, strings)
+        val b = factors.zygoM[String, Int, Int \/ ?](
+          eval.generalizeM[Int \/ ?], strings(_).right)
+
+        a.right ?= b
+      }
+    }
+
+    "elgotZygo" >> {
+      "eval and elgotStrings" in {
+        testRec(
+          mul(mul(num(0), num(0)), mul(num(2), num(5))),
+          new RecRunner[Exp, Int \/ String] {
+            def run[T](implicit TR: Recursive.Aux[T, Exp], TC: Corecursive.Aux[T, Exp]) =
+              _.elgotZygoM[String, Int, Int \/ ?](
+                eval.generalizeM[Int \/ ?],
+                elgotStrings(_).right
+              ) must equal("((0 * 0 = 0) * (2 * 5 = 10) = 0)".right)
+          })
+      }
+    }
+
+    "elgotZygoM" >> {
+      "behave like elgotZygo" >> prop { (i: Int) =>
+        val factors = i.ana[Fix[Exp]](extractFactors2)
+
+        val a = factors.elgotZygo(eval, elgotStrings)
+        val b = factors.elgotZygoM[String, Int, Int \/ ?](
+          eval.generalizeM[Int \/ ?], elgotStrings(_).right)
+
+        a.right ?= b
+      }
+    }
+  }
+}


### PR DESCRIPTION
I'm developing compiler with matryoshka, my original motivation is to annotate tree with types, and then compile, both phases operate under `M = Error \/ ?`. Basically, I want to do zygomorphism where both algebras are effectful.

I'm very new to recursion schemes, but I have a feeling there is something wrong because I wasn't able to describe `zygoM` in terms of `gcataM`. I'm not sure that this function is called `zygoM`, because probably it should be:

```scala
  def zygoM[A, B, M[_]: Monad]
    (t: T)
    (f: Algebra[Base, B], g: GAlgebraM[(B, ?), M, Base, A])
    (implicit BF: Traverse[Base])
      : M[A]
```

But then I'm not sure what is the right function for the particular use case I had.

I didn't add any tests because I'm not yet sure this is the right thing. I would be glad to get any help or feedback on this.