### PR TITLE
Define more operations in terms of cata, ana, and hylo.

### DIFF
--- a/core/shared/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Corecursive.scala
@@ -32,7 +32,7 @@ trait Corecursive[T] extends Based[T] {
     (f: CoalgebraM[M, Base, A])
     (implicit BT: Traverse[Base])
       : M[T] =
-    f(a).flatMap(_.traverse(anaM(_)(f))) ∘ (embed(_))
+    hyloM[M, Base, A, T](a)(embed(_).point[M], f)
 
   def gana[N[_]: Monad, A]
     (a: A)
@@ -45,12 +45,8 @@ trait Corecursive[T] extends Based[T] {
     a: A)(
     k: DistributiveLaw[N, Base], f: GCoalgebraM[N, M, Base, A])(
     implicit BT: Traverse[Base]):
-      M[T] = {
-    def loop(x: N[Base[N[A]]]): M[T] =
-      k(x).traverse(_.join.traverse(f) >>= loop) ∘ (embed(_))
-
-    f(a) ∘ (_.point[N]) >>= loop
-  }
+      M[T] =
+    ghyloM[Id, N, M, Base, A, T](a)(distCata, k, embed(_).point[M], f)
 
   def elgotAna[N[_]: Monad, A](
     a: A)(

--- a/core/shared/src/main/scala/matryoshka/Corecursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Corecursive.scala
@@ -51,8 +51,9 @@ trait Corecursive[T] extends Based[T] {
   def elgotAna[N[_]: Monad, A](
     a: A)(
     k: DistributiveLaw[N, Base], ψ: ElgotCoalgebra[N, Base, A])(
-    implicit BF: Functor[Base]):
-      T = ana(ψ(a)) { nfa => k(nfa) ∘ { _ >>= ψ } }
+    implicit BF: Functor[Base])
+      : T =
+    ana(ψ(a))(k(_) ∘ (_ >>= ψ))
 
   /** An unfold that can short-circuit certain sections.
     */

--- a/core/shared/src/main/scala/matryoshka/CorecursiveT.scala
+++ b/core/shared/src/main/scala/matryoshka/CorecursiveT.scala
@@ -16,7 +16,7 @@
 
 package matryoshka
 
-import scalaz._, Scalaz._
+import scalaz._
 
 /** This is a workaround for a certain use case (e.g.,
   * [[matryoshka.patterns.Diff]] and [[matryoshka.patterns.PotentialFailure]]).
@@ -25,8 +25,9 @@ import scalaz._, Scalaz._
 // NB: Not a `@typeclass` because we don’t want to inject these operations.
 trait CorecursiveT[T[_[_]]] {
   def embedT[F[_]: Functor](t: F[T[F]]): T[F]
+
   def anaT[F[_]: Functor, A](a: A)(f: Coalgebra[F, A]): T[F] =
-    embedT(f(a) ∘ (anaT(_)(f)))
+    hylo(a)(embedT[F], f)
 }
 
 object CorecursiveT {

--- a/core/shared/src/main/scala/matryoshka/Recursive.scala
+++ b/core/shared/src/main/scala/matryoshka/Recursive.scala
@@ -32,35 +32,27 @@ trait Recursive[T] extends Based[T] {
   def project(t: T)(implicit BF: Functor[Base]): BaseT[T]
 
   def cata[A](t: T)(f: Algebra[Base, A])(implicit BF: Functor[Base]): A =
-    f(project(t) ∘ (cata(_)(f)))
+    hylo(t)(f, project)
 
   /** A Kleisli catamorphism. */
   def cataM[M[_]: Monad, A](t: T)(f: AlgebraM[M, Base, A])(implicit BT: Traverse[Base]):
       M[A] =
-    project(t).traverse(cataM(_)(f)).flatMap(f)
+    cata[M[A]](t)(_.sequence >>= f)
 
   /** A catamorphism generalized with a comonad inside the functor. */
   def gcata[W[_]: Comonad, A]
     (t: T)
     (k: DistributiveLaw[Base, W], g: GAlgebra[W, Base, A])
     (implicit BF: Functor[Base])
-      : A = {
-    def loop(t: T): W[Base[W[A]]] = k(project(t) ∘ (loop(_).map(g).cojoin))
+      : A =
+    cata[W[A]](t)(fwa => k(fwa.map(_.cojoin)).map(g)).copoint
 
-    g(loop(t).copoint)
-  }
-
-  def gcataM[W[_]: Comonad : Traverse, M[_]: Monad, A]
+  def gcataM[W[_]: Comonad: Traverse, M[_]: Monad, A]
     (t: T)
-    (w: DistributiveLaw[Base, (M ∘ W)#λ], g: GAlgebraM[W, M, Base, A])
+    (w: DistributiveLaw[Base, W], g: GAlgebraM[W, M, Base, A])
     (implicit BT: Traverse[Base])
-      : M[A] = {
-    def loop(t: T): M[W[Base[W[A]]]] =
-      project(t).traverse(loop(_) >>=
-        (_.traverse(g) ∘ (_.cojoin))) ∘ (_ ∘ (_.point[M])) >>= (w(_))
-
-    loop(t) ∘ (_.copoint) >>= g
-  }
+      : M[A] =
+    cataM[M, W[A]](t)(fwa => w(fwa.map(_.cojoin)).traverse(g)) ∘ (_.copoint)
 
   /** A catamorphism generalized with a comonad outside the functor. */
   def elgotCata[W[_]: Comonad, A](
@@ -121,7 +113,10 @@ trait Recursive[T] extends Based[T] {
     (f: AlgebraM[M, Base, B], g: GAlgebraM[(B, ?), M, Base, A])
     (implicit BT: Traverse[Base])
       : M[A] =
-    gcataM[(B, ?), M, A](t)(distZygoM(f, distApplicative[Base, M]), g)
+    gcataM[(M[B], ?), M, A](
+      t)(
+      distZygo(_.sequence >>= f),
+        _.traverse(Bitraverse[(?, ?)].leftTraverse.sequence[M, B]) >>= g)
 
   def elgotZygo[A, B]
     (t: T)
@@ -304,14 +299,14 @@ trait Recursive[T] extends Based[T] {
     (f: Base[U] => G[U])
     (implicit U: Corecursive.Aux[U, G], BF: Functor[Base])
       : U =
-    mapR(t)(ft => f(ft.map(transCata(_)(f))))
+    cata(t)(f >>> (U.embed(_)))
 
   def transAna[U, G[_]: Functor]
     (t: T)
     (f: Base[T] => G[T])
     (implicit U: Corecursive.Aux[U, G], BF: Functor[Base])
       : U =
-    mapR(t)(f(_).map(transAna(_)(f)))
+    U.ana(t)(f <<< project)
 
   def transPostpro[U, G[_]: Functor]
     (t: T)
@@ -346,14 +341,14 @@ trait Recursive[T] extends Based[T] {
     (f: TransformM[M, U, Base, G])
     (implicit U: Corecursive.Aux[U, G], BT: Traverse[Base])
       : M[U] =
-    traverseR(t)(_.traverse(transCataM(_)(f)).flatMap(f))
+    cataM(t)(f(_) ∘ (U.embed(_)))
 
   def transAnaM[M[_]: Monad, U, G[_]: Traverse]
     (t: T)
     (f: TransformM[M, T, Base, G])
     (implicit U: Corecursive.Aux[U, G], BF: Functor[Base])
       : M[U] =
-    traverseR(t)(f(_).flatMap(_.traverse(transAnaM(_)(f))))
+    U.anaM(t)(f <<< project)
 
   // TODO: Move these operations to `Birecursive` once #44 is fixed.
 
@@ -500,7 +495,7 @@ object Recursive {
         : A =
       typeClassInstance.gcata[W, A](self)(k, g)
     def gcataM[W[_]: Comonad: Traverse, M[_]: Monad, A]
-      (w: DistributiveLaw[F, (M ∘ W)#λ], g: GAlgebraM[W, M, F, A])
+      (w: DistributiveLaw[F, W], g: GAlgebraM[W, M, F, A])
       (implicit BT: Traverse[F])
         : M[A] =
       typeClassInstance.gcataM[W, M, A](self)(w, g)

--- a/core/shared/src/main/scala/matryoshka/RecursiveT.scala
+++ b/core/shared/src/main/scala/matryoshka/RecursiveT.scala
@@ -18,7 +18,7 @@ package matryoshka
 
 import slamdata.Predef._
 
-import scalaz._, Scalaz._
+import scalaz._
 
 /** This is a workaround for a certain use case (e.g.,
   * [[matryoshka.patterns.Diff]] and [[matryoshka.patterns.PotentialFailure]]).
@@ -31,7 +31,7 @@ trait RecursiveT[T[_[_]]] extends Serializable {
   def projectT[F[_]: Functor](t: T[F]): F[T[F]]
 
   def cataT[F[_]: Functor, A](t: T[F])(f: Algebra[F, A]): A =
-    f(projectT(t) ∘ (cataT(_)(f)))
+    hylo(t)(f, projectT[F])
 }
 
 object RecursiveT {

--- a/core/shared/src/main/scala/matryoshka/instances/fixedpoint/package.scala
+++ b/core/shared/src/main/scala/matryoshka/instances/fixedpoint/package.scala
@@ -222,6 +222,7 @@ package object fixedpoint {
 
     /** Run to completion (if it completes).
       */
+    // TODO: Alternatively `self.cata[A](_.merge)`, but that's not tailrec.
     @tailrec final def unsafePerformSync: A = self.project match {
       case -\/(a) => a
       case \/-(p) => p.unsafePerformSync

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -225,9 +225,12 @@ package object matryoshka {
     *
     * @group refolds
     */
-  def hyloM[M[_]: Monad, F[_]: Traverse, A, B](a: A)(f: AlgebraM[M, F, B], g: CoalgebraM[M, F, A]):
-      M[B] =
-    g(a) >>= (_.traverse(hyloM(_)(f, g)) >>= f)
+  def hyloM[M[_], F[_], A, B]
+    (a: A)
+    (f: AlgebraM[M, F, B], g: CoalgebraM[M, F, A])
+    (implicit M: Monad[M], F: Traverse[F])
+      : M[B] =
+    hylo[(M ∘ F)#λ, A, M[B]](a)(_ >>= (_.sequence >>= f), g)(M compose F)
 
   /** `histo ⋘ ana`
     *
@@ -261,10 +264,10 @@ package object matryoshka {
     n: DistributiveLaw[N, F],
     f: GAlgebra[W, F, B],
     g: GCoalgebra[N, F, A]):
-      B = {
-    def h(x: N[A]): W[B] = w(n(x ∘ g) ∘ (y => h(y.join).cojoin)) ∘ f
-    h(a.point[N]).copoint
-  }
+      B =
+    hylo[Yoneda[F, ?], N[A], W[B]](
+      a.point[N])(
+      fwb => w((fwb ∘ (_.cojoin)).run) ∘ f, na => Yoneda(n(na ∘ g)) ∘ (_.join)).copoint
 
   /** A Kleisli `ghylo` (`gcataM ⋘ ganaM`)
     *
@@ -273,17 +276,15 @@ package object matryoshka {
   def ghyloM[W[_]: Comonad: Traverse, N[_]: Monad: Traverse, M[_]: Monad, F[_]: Traverse, A, B](
     a: A)(
     w: DistributiveLaw[F, W],
-    m: DistributiveLaw[N, F],
+    n: DistributiveLaw[N, F],
     f: GAlgebraM[W, M, F, B],
     g: GCoalgebraM[N, M, F, A]):
-      M[B] = {
-    def h(x: N[A]): M[W[B]] =
-      (x.traverse(g) >>=
-        (m(_: N[F[N[A]]]).traverse(y => h(y.join) ∘ (_.cojoin)))) ∘
-        (w(_)) >>=
-        (_.traverse(f))
-    h(a.point[N]) ∘ (_.copoint)
-  }
+      M[B] =
+    hyloM[M, F, N[A], W[B]](
+      a.point[N])(
+      fwb => w(fwb ∘ (_.cojoin)).traverse(f),
+        na => na.traverse(g) ∘ (n(_) ∘ (_.join))) ∘
+      (_.copoint)
 
   /** Similar to a hylomorphism, this composes a futumorphism and a
     * histomorphism.
@@ -300,32 +301,37 @@ package object matryoshka {
     *
     * @group refolds
     */
-  def elgot[F[_]: Functor, A, B](a: A)(φ: Algebra[F, B], ψ: ElgotCoalgebra[B \/ ?, F, A]): B = {
-    def h: A => B =
-      (((x: B) => x) ||| ((x: F[A]) => φ(x ∘ h))) ⋘ ψ
-    h(a)
-  }
+  def elgot[F[_], A, B]
+    (a: A)
+    (φ: Algebra[F, B], ψ: ElgotCoalgebra[B \/ ?, F, A])
+    (implicit F: Functor[F])
+      : B =
+    hylo[((B \/ ?) ∘ F)#λ, A, B](a)(_.fold(x => x, φ), ψ)(Functor[B \/ ?] compose F)
 
   /** `cataM ⋘ elgotGApoM`
     *
     * @group refolds
     */
-  def elgotM[M[_]: Monad, F[_]: Traverse, A, B](a: A)(φ: AlgebraM[M, F, B], ψ: ElgotCoalgebraM[B \/ ?, M, F, A]):
-      M[B] = {
-    def h(a: A): M[B] = ψ(a) >>= (_.traverse(_.traverse(h) >>= φ).map(_.merge))
-    h(a)
-  }
+  def elgotM[M[_], F[_], A, B]
+    (a: A)
+    (φ: AlgebraM[M, F, B], ψ: ElgotCoalgebraM[B \/ ?, M, F, A])
+    (implicit M: Monad[M], F: Traverse[F])
+      : M[B] =
+    hyloM[M, ((B \/ ?) ∘ F)#λ, A, B](
+      a)(
+      _.fold(_.point[M], φ), ψ)(
+      M, Traverse[B \/ ?] compose F)
 
   /** `elgotZygo ⋘ ana`
     *
     * @group refolds
     */
-  def coelgot[F[_]: Functor, A, B](a: A)(φ: ElgotAlgebra[(A, ?), F, B], ψ: Coalgebra[F, A]):
-      B = {
-    def h: A => B =
-      φ ⋘ (((x: A) => x) &&& (((x: F[A]) => x ∘ h) ⋘ ψ))
-    h(a)
-  }
+  def coelgot[F[_], A, B]
+    (a: A)
+    (φ: ElgotAlgebra[(A, ?), F, B], ψ: Coalgebra[F, A])
+    (implicit F: Functor[F])
+      : B =
+    hylo[((A, ?) ∘ F)#λ, A, B](a)(φ, a => (a, ψ(a)))(Functor[(A, ?)] compose F)
 
   /** `elgotZygoM ⋘ anaM`
     *
@@ -334,14 +340,12 @@ package object matryoshka {
   object coelgotM {
     def apply[M[_]] = new PartiallyApplied[M]
     final class PartiallyApplied[M[_]] {
-      def apply[F[_]: Traverse, A, B]
+      def apply[F[_], A, B]
         (a: A)
         (φ: ElgotAlgebraM[(A, ?), M, F, B], ψ: CoalgebraM[M, F, A])
-        (implicit M: Monad[M])
-          : M[B] = {
-        def h(a: A): M[B] = ψ(a) >>= (_.traverse(h)) >>= (x => φ((a, x)))
-        h(a)
-      }
+        (implicit M: Monad[M], F: Traverse[F])
+          : M[B] =
+        hyloM[M, ((A, ?) ∘ F)#λ, A, B](a)(φ, a => ψ(a) strengthL a)(M, Traverse[(A, ?)] compose F)
     }
   }
 

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -345,7 +345,10 @@ package object matryoshka {
         (φ: ElgotAlgebraM[(A, ?), M, F, B], ψ: CoalgebraM[M, F, A])
         (implicit M: Monad[M], F: Traverse[F])
           : M[B] =
-        hyloM[M, ((A, ?) ∘ F)#λ, A, B](a)(φ, a => ψ(a) strengthL a)(M, Traverse[(A, ?)] compose F)
+        hyloM[M, ((A, ?) ∘ F)#λ, A, B](
+          a)(
+          φ, a => ψ(a) strengthL a)(
+          M, Traverse[(A, ?)] compose F)
     }
   }
 

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -213,13 +213,16 @@ package object matryoshka {
     */
   type DistributiveLaw[F[_], G[_]] = (F ∘ G)#λ ~> (G ∘ F)#λ
 
-  /** Composition of an anamorphism and a catamorphism that avoids building the
-    * intermediate recursive data structure.
+  /** The hylomorphism is the fundamental operation of recursion schemes. It
+    * first applies `ψ`, recursively breaking an `A` into layers of `F`, then
+    * applies `φ`, combining the `F`s into a `B`. It can also be seen as the
+    * (fused) composition of an anamorphism and a catamorphism that avoids
+    * building the intermediate recursive data structure.
     *
     * @group refolds
     */
-  def hylo[F[_]: Functor, A, B](a: A)(f: Algebra[F, B], g: Coalgebra[F, A]): B =
-    f(g(a) ∘ (hylo(_)(f, g)))
+  def hylo[F[_]: Functor, A, B](a: A)(φ: Algebra[F, B], ψ: Coalgebra[F, A]): B =
+    φ(ψ(a) ∘ (hylo(_)(φ, ψ)))
 
   /** A Kleisli hylomorphism.
     *

--- a/tests/shared/src/test/scala/matryoshka/instances/fixedpoint/partial.scala
+++ b/tests/shared/src/test/scala/matryoshka/instances/fixedpoint/partial.scala
@@ -100,7 +100,7 @@ class PartialSpec extends Specification with ScalazMatchers with ScalaCheck {
 
     // TODO: Should work with any Int, but stack overflows on big negatives.
     "always terminate with mc91" >> prop { (n: Int) =>
-      n > -3000 ==>
+      n > -90000 ==>
         (mc91(n).unsafePerformSync must equal(if (n <= 100) 91 else n - 10))
     }
   }

--- a/tests/shared/src/test/scala/matryoshka/spec.scala
+++ b/tests/shared/src/test/scala/matryoshka/spec.scala
@@ -170,20 +170,20 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
 
     "universe" >> {
       "be one for simple literal" in {
-        num(1).universe must equal(List(num(1)))
+        num(1).universe must equal(NonEmptyList(num(1)))
         num(1).convertTo[Mu[Exp]].universe must
-          equal(List(num(1)).map(_.convertTo[Mu[Exp]]))
+          equal(NonEmptyList(num(1)).map(_.convertTo[Mu[Exp]]))
         num(1).convertTo[Nu[Exp]].universe must
-          equal(List(num(1)).map(_.convertTo[Nu[Exp]]))
+          equal(NonEmptyList(num(1)).map(_.convertTo[Nu[Exp]]))
       }
 
       "contain root and sub-expressions" in {
         mul(num(1), num(2)).universe must
-          equal(List(mul(num(1), num(2)), num(1), num(2)))
+          equal(NonEmptyList(mul(num(1), num(2)), num(1), num(2)))
         mul(num(1), num(2)).convertTo[Mu[Exp]].universe must
-          equal(List(mul(num(1), num(2)), num(1), num(2)).map(_.convertTo[Mu[Exp]]))
+          equal(NonEmptyList(mul(num(1), num(2)), num(1), num(2)).map(_.convertTo[Mu[Exp]]))
         mul(num(1), num(2)).convertTo[Nu[Exp]].universe must
-          equal(List(mul(num(1), num(2)), num(1), num(2)).map(_.convertTo[Nu[Exp]]))
+          equal(NonEmptyList(mul(num(1), num(2)), num(1), num(2)).map(_.convertTo[Nu[Exp]]))
       }
     }
 
@@ -1033,12 +1033,12 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
     "foldMap" >> {
       "zeros" >> Prop.forAll(expGen) { exp =>
         Foldable[Cofree[Exp, ?]].foldMap(exp.cata(attrK(0)))(_ :: Nil) must
-          equal(exp.universe.map(Function.const(0)))
+          equal(exp.universe.map(Function.const(0)).toList)
       }
 
       "selves" >> Prop.forAll(expGen) { exp =>
         Foldable[Cofree[Exp, ?]].foldMap(exp.cata[Cofree[Exp, Mu[Exp]]](attrSelf))(_ :: Nil) must
-          equal(exp.universe)
+          equal(exp.universe.toList)
       }
     }
   }


### PR DESCRIPTION
This is especially useful for Mu/Nu, since these operations will now use the specialized ana/cata rather than the naïve implementations.

Also greatly reduces the number of places we use general recursion.