### PR TITLE
Generalize the various attribute* algebras.

### DIFF
--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -108,13 +108,13 @@ package object matryoshka {
     * in bottom-up fashion.
     * @group algebras
     */
-  type ElgotAlgebraicTransformM[W[_], M[_], T, F[_], G[_]] = W[F[T]] => M[G[T]]
+  type AlgebraicElgotTransformM[W[_], M[_], T, F[_], G[_]] = W[F[T]] => M[G[T]]
 
   /** Transform a structure `F` contained in `W`, to a structure `G`,
     * in bottom-up fashion.
     * @group algebras
     */
-  type ElgotAlgebraicTransform[W[_], T, F[_], G[_]] = W[F[T]] => G[T]
+  type AlgebraicElgotTransform[W[_], T, F[_], G[_]] = W[F[T]] => G[T]
 
   /** Transform a structure `F` to a structure `G` containing values in `N`,
     * in top-down fashion, accumulating effects in the monad `M`.
@@ -665,7 +665,7 @@ package object matryoshka {
       def apply[F[_]: Functor, A]
         (f: ElgotAlgebraM[W, M, F, A])
         (implicit W: Comonad[W], M: Functor[M], T: Recursive.Aux[T, EnvT[A, F, ?]])
-          : ElgotAlgebraicTransformM[W, M, T, F, EnvT[A, F, ?]] =
+          : AlgebraicElgotTransformM[W, M, T, F, EnvT[A, F, ?]] =
         node => f(node ∘ (_ ∘ (_.project.ask))) ∘ (a => EnvT((a, node.copoint)))
     }
   }
@@ -681,7 +681,7 @@ package object matryoshka {
       def apply[F[_]: Functor, A]
         (f: ElgotAlgebra[W, F, A])
         (implicit W: Comonad[W], T: Recursive.Aux[T, EnvT[A, F, ?]])
-          : ElgotAlgebraicTransform[W, T, F, EnvT[A, F, ?]] =
+          : AlgebraicElgotTransform[W, T, F, EnvT[A, F, ?]] =
         attributeElgotM[W, Id, T](f)
     }
   }

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -104,6 +104,18 @@ package object matryoshka {
     */
   type AlgebraicGTransform[W[_], T, F[_], G[_]]        = F[W[T]] => G[T]
 
+  /** Transform a structure `F` contained in `W`, to a structure `G`,
+    * in bottom-up fashion.
+    * @group algebras
+    */
+  type ElgotAlgebraicTransformM[W[_], M[_], T, F[_], G[_]] = W[F[T]] => M[G[T]]
+
+  /** Transform a structure `F` contained in `W`, to a structure `G`,
+    * in bottom-up fashion.
+    * @group algebras
+    */
+  type ElgotAlgebraicTransform[W[_], T, F[_], G[_]] = W[F[T]] => G[T]
+
   /** Transform a structure `F` to a structure `G` containing values in `N`,
     * in top-down fashion, accumulating effects in the monad `M`.
     * @group algebras
@@ -647,12 +659,30 @@ package object matryoshka {
     * @group algtrans
     */
   object attributeElgotM {
-    def apply[W[_], M[_]] = new PartiallyApplied[W, M]
+    def apply[W[_], M[_], T] = new PartiallyApplied[W, M, T]
 
-    final class PartiallyApplied[W[_], M[_]] {
-      def apply[F[_]: Functor, A](f: ElgotAlgebraM[W, M, F, A])(implicit W: Comonad[W], M: Functor[M]):
-          ElgotAlgebraM[W, M, F, Cofree[F, A]] =
-        node => f(node ∘ (_ ∘ (_.head))) ∘ (Cofree(_, node.copoint))
+    final class PartiallyApplied[W[_], M[_], T] {
+      def apply[F[_]: Functor, A]
+        (f: ElgotAlgebraM[W, M, F, A])
+        (implicit W: Comonad[W], M: Functor[M], T: Recursive.Aux[T, EnvT[A, F, ?]])
+          : ElgotAlgebraicTransformM[W, M, T, F, EnvT[A, F, ?]] =
+        node => f(node ∘ (_ ∘ (_.project.ask))) ∘ (a => EnvT((a, node.copoint)))
+    }
+  }
+
+  /**
+    *
+    * @group algtrans
+    */
+  object attributeElgot {
+    def apply[W[_], T] = new PartiallyApplied[W, T]
+
+    final class PartiallyApplied[W[_], T] {
+      def apply[F[_]: Functor, A]
+        (f: ElgotAlgebra[W, F, A])
+        (implicit W: Comonad[W], T: Recursive.Aux[T, EnvT[A, F, ?]])
+          : ElgotAlgebraicTransform[W, T, F, EnvT[A, F, ?]] =
+        attributeElgotM[W, Id, T](f)
     }
   }
 

--- a/core/shared/src/main/scala/matryoshka/package.scala
+++ b/core/shared/src/main/scala/matryoshka/package.scala
@@ -556,7 +556,7 @@ package object matryoshka {
    if (index < 0) None
    else fa.toList.drop(index).headOption
 
-  /** Turns any F-algebra, into an identical one that attributes the tree with
+  /** Turns any F-algebra, into a transform that attributes the tree with
     * the results for each node.
     *
     * @group algtrans
@@ -567,9 +567,9 @@ package object matryoshka {
     final class PartiallyApplied[T] {
       def apply[F[_]: Functor, M[_]: Functor, A]
         (f: AlgebraM[M, F, A])
-        (implicit T: Birecursive.Aux[T, EnvT[A, F, ?]])
-          : AlgebraM[M, F, T] =
-        fa => f(fa ∘ (_.project.ask)) ∘ (a => EnvT((a, fa)).embed)
+        (implicit T: Recursive.Aux[T, EnvT[A, F, ?]])
+          : TransformM[M, T, F, EnvT[A, F, ?]] =
+        fa => f(fa ∘ (_.project.ask)) ∘ (a => EnvT((a, fa)))
     }
   }
 
@@ -583,8 +583,8 @@ package object matryoshka {
     final class PartiallyApplied[T] {
       def apply[F[_]: Functor, A]
         (f: Algebra[F, A])
-        (implicit T: Birecursive.Aux[T, EnvT[A, F, ?]])
-          : Algebra[F, T] =
+        (implicit T: Recursive.Aux[T, EnvT[A, F, ?]])
+          : Transform[T, F, EnvT[A, F, ?]] =
         attributeAlgebraM[T][F, Id, A](f)
     }
   }
@@ -621,8 +621,8 @@ package object matryoshka {
     final class PartiallyApplied[T] {
       def apply[F[_]: Functor, A]
         (k: A)
-        (implicit T: Birecursive.Aux[T, EnvT[A, F, ?]])
-          : Algebra[F, T] =
+        (implicit T: Recursive.Aux[T, EnvT[A, F, ?]])
+          : Transform[T, F, EnvT[A, F, ?]] =
         attributeAlgebra[T](Function.const[A, F[A]](k))
     }
   }
@@ -636,8 +636,8 @@ package object matryoshka {
 
     final class PartiallyApplied[T] {
       def apply[U, F[_]: Functor]
-        (implicit T: Birecursive.Aux[T, EnvT[U, F, ?]], U: Corecursive.Aux[U, F])
-          : Algebra[F, T] =
+        (implicit T: Recursive.Aux[T, EnvT[U, F, ?]], U: Corecursive.Aux[U, F])
+          : Transform[T, F, EnvT[U, F, ?]] =
         attributeAlgebra[T](U.embed(_: F[U]))
     }
   }

--- a/tests/shared/src/test/scala/matryoshka/spec.scala
+++ b/tests/shared/src/test/scala/matryoshka/spec.scala
@@ -23,6 +23,7 @@ import matryoshka.exp2._
 import matryoshka.helpers._
 import matryoshka.implicits._
 import matryoshka.instances.fixedpoint.{Nat, Partial, partialMonad, PartialOps, RecursiveOptionOps}
+import matryoshka.patterns._
 import matryoshka.runners._
 import matryoshka.scalacheck.arbitrary._
 import matryoshka.scalacheck.cogen._
@@ -566,12 +567,14 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
 
     "attributeElgotM" >> {
       "fold to Cofree" in {
+        type T = Cofree[Exp, Int]
+
         Cofree[Exp, Int](1, Mul(
           Cofree(2, Num(1)),
           Cofree(2, Mul(
             Cofree(3, Num(2)),
             Cofree(3, Num(3))))))
-          .cataM(liftTM(attributeElgotM[(Int, ?), Option](weightedEval))) must
+          .transCataM(((_: EnvT[Int, Exp, T]).run) >>> attributeElgotM[(Int, ?), Option, T](weightedEval)) must
           equal(
             Cofree[Exp, Int](216, Mul(
               Cofree(2, Num(1)),
@@ -1113,8 +1116,6 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
   }
 
   "recover" should {
-    import matryoshka.patterns._
-
     "handle “partially-folded” values" in {
       val exp =
         CoEnv[Int, Exp, Fix[CoEnv[Int, Exp, ?]]](\/-(Mul(

--- a/tests/shared/src/test/scala/matryoshka/spec.scala
+++ b/tests/shared/src/test/scala/matryoshka/spec.scala
@@ -1018,27 +1018,29 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
   }
 
   "Attr" >> {
+    type T[A] = Cofree[Exp, A]
+
     "attrSelf" >> {
       "annotate all" >> Prop.forAll(expGen) { exp =>
-        exp.cata(attrSelf[Mu[Exp], Exp]).elgotPara(universe) must
-          equal(exp.elgotPara(universe).map(_.cata(attrSelf[Mu[Exp], Exp])))
+        exp.cata(attrSelf[T[Mu[Exp]]].apply).elgotPara(universe) must
+          equal(exp.elgotPara(universe).map(_.cata(attrSelf[T[Mu[Exp]]].apply)))
       }
     }
 
     "convert" >> {
       "forget unit" >> Prop.forAll(expGen) { exp =>
-        exp.cata(attrK(())).cata(deattribute[Exp, Unit, Mu[Exp]](_.embed)) must equal(exp)
+        exp.cata(attrK[T[Unit]](())).cata(deattribute[Exp, Unit, Mu[Exp]](_.embed)) must equal(exp)
       }
     }
 
     "foldMap" >> {
       "zeros" >> Prop.forAll(expGen) { exp =>
-        Foldable[Cofree[Exp, ?]].foldMap(exp.cata(attrK(0)))(_ :: Nil) must
+        Foldable[Cofree[Exp, ?]].foldMap(exp.cata(attrK[T[Int]](0)))(_ :: Nil) must
           equal(exp.elgotPara(universe).map(Function.const(0)).toList)
       }
 
       "selves" >> Prop.forAll(expGen) { exp =>
-        Foldable[Cofree[Exp, ?]].foldMap(exp.cata[Cofree[Exp, Mu[Exp]]](attrSelf))(_ :: Nil) must
+        Foldable[Cofree[Exp, ?]].foldMap(exp.cata[T[Mu[Exp]]](attrSelf[T[Mu[Exp]]].apply))(_ :: Nil) must
           equal(exp.elgotPara(universe).toList)
       }
     }

--- a/tests/shared/src/test/scala/matryoshka/spec.scala
+++ b/tests/shared/src/test/scala/matryoshka/spec.scala
@@ -1022,25 +1022,25 @@ class MatryoshkaSpecs extends Specification with ScalaCheck with ScalazMatchers 
 
     "attrSelf" >> {
       "annotate all" >> Prop.forAll(expGen) { exp =>
-        exp.cata(attrSelf[T[Mu[Exp]]].apply).elgotPara(universe) must
-          equal(exp.elgotPara(universe).map(_.cata(attrSelf[T[Mu[Exp]]].apply)))
+        exp.transCata[T[Mu[Exp]]](attrSelf[T[Mu[Exp]]].apply).elgotPara(universe) must
+          equal(exp.elgotPara(universe).map(_.transCata[T[Mu[Exp]]](attrSelf[T[Mu[Exp]]].apply)))
       }
     }
 
     "convert" >> {
       "forget unit" >> Prop.forAll(expGen) { exp =>
-        exp.cata(attrK[T[Unit]](())).cata(deattribute[Exp, Unit, Mu[Exp]](_.embed)) must equal(exp)
+        exp.transCata[T[Unit]](attrK[T[Unit]](())).cata(deattribute[Exp, Unit, Mu[Exp]](_.embed)) must equal(exp)
       }
     }
 
     "foldMap" >> {
       "zeros" >> Prop.forAll(expGen) { exp =>
-        Foldable[Cofree[Exp, ?]].foldMap(exp.cata(attrK[T[Int]](0)))(_ :: Nil) must
+        Foldable[Cofree[Exp, ?]].foldMap(exp.transCata[T[Int]](attrK[T[Int]](0)))(_ :: Nil) must
           equal(exp.elgotPara(universe).map(Function.const(0)).toList)
       }
 
       "selves" >> Prop.forAll(expGen) { exp =>
-        Foldable[Cofree[Exp, ?]].foldMap(exp.cata[T[Mu[Exp]]](attrSelf[T[Mu[Exp]]].apply))(_ :: Nil) must
+        Foldable[Cofree[Exp, ?]].foldMap(exp.transCata[T[Mu[Exp]]](attrSelf[T[Mu[Exp]]].apply))(_ :: Nil) must
           equal(exp.elgotPara(universe).toList)
       }
     }


### PR DESCRIPTION
Generalizes the various `attribute*` algebras to work for any `[T, F[_], A] => Birecursive.Aux[T, EnvT[A, F, ?]]`.